### PR TITLE
fix: auto-detect cloned repo and add template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,29 @@ The goal: zero warm-up time. Your first Claude Code session starts productive.
 
 ## Quick Start
 
+### Option A: GitHub Template (Recommended)
+
+1. Click **"Use this template"** at the top of this repo
+2. Name your new repository and create it
+3. Clone your new repo and run the init script:
+
 ```bash
-# Clone the template
-git clone https://github.com/sakebomb/scaffolding.git my-project
+git clone https://github.com/you/my-project.git
 cd my-project
-
-# Run the init script
 ./scaffold
-
-# Start working
 claude
 ```
+
+### Option B: Git Clone
+
+```bash
+git clone https://github.com/sakebomb/scaffolding.git my-project
+cd my-project
+./scaffold
+claude
+```
+
+The scaffold script detects the cloned scaffolding history and reinitializes git automatically.
 
 ## What the Init Flow Looks Like
 

--- a/scaffold
+++ b/scaffold
@@ -714,21 +714,19 @@ cleanup_artifacts() {
 init_git() {
   header "Git Initialization"
 
-  # Check if already a git repo
+  # If cloned from scaffolding repo, remove the cloned .git to start fresh
+  if [[ -d "$SCRIPT_DIR/.git" ]]; then
+    local remote_url
+    remote_url="$(git -C "$SCRIPT_DIR" remote get-url origin 2>/dev/null || echo "")"
+    if [[ "$remote_url" == *"sakebomb/scaffolding"* ]]; then
+      info "Removing cloned scaffolding git history..."
+      rm -rf "$SCRIPT_DIR/.git"
+    fi
+  fi
+
+  # Initialize or verify git repo
   if [[ -d "$SCRIPT_DIR/.git" ]]; then
     info "Git repo already exists."
-
-    # Check if we're on main/master and create a feature branch
-    local current_branch
-    current_branch="$(git -C "$SCRIPT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "none")"
-    if [[ "$current_branch" == "main" || "$current_branch" == "master" || "$current_branch" == "none" ]]; then
-      # If there are no commits yet, rename the branch to main
-      local has_commits
-      has_commits="$(git -C "$SCRIPT_DIR" rev-list --count HEAD 2>/dev/null || echo "0")"
-      if [[ "$has_commits" == "0" ]]; then
-        git -C "$SCRIPT_DIR" checkout -b main 2>/dev/null || true
-      fi
-    fi
   else
     info "Initializing git repository..."
     git -C "$SCRIPT_DIR" init -b main


### PR DESCRIPTION
## Summary

- Scaffold script now detects when cloned from `sakebomb/scaffolding` and removes the cloned `.git` before reinitializing
- Repo enabled as a GitHub template ("Use this template" button)
- README updated with two Quick Start paths: template (recommended) and clone

## Test plan

- [x] `bash tests/test_scaffold.sh` — 272/272 passing
- [x] Template repo setting enabled via API (`is_template: true`)
- [ ] Verify "Use this template" button appears on repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)