### PR TITLE
feat: add GitHub project management integration

### DIFF
--- a/.claude/skills/backlog/SKILL.md
+++ b/.claude/skills/backlog/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: backlog
+description: Manage GitHub issues backlog — view, pick, or create work items
+argument-hint: "[show|new|pick #N|close #N]"
+user-invocable: true
+allowed-tools: "Read, Write, Edit, Bash(gh *), Bash(git checkout*), Bash(git branch*), Bash(git status*)"
+---
+
+Manage the GitHub issues backlog. Bridge between GitHub Issues and local task management.
+
+## Commands
+
+Parse `$ARGUMENTS` to determine the action:
+
+### `show` (default — when no argument or `show`)
+
+1. Run `gh issue list --state open --limit 20` to get open issues.
+2. Group by priority label (`P0-critical`, `P1-high`, `P2-medium`, `P3-low`, unlabeled).
+3. Present a summary:
+
+```
+## Open Issues
+
+### P0 — Critical
+- #12 Fix auth token expiration (bug, in-progress)
+
+### P1 — High
+- #8 Add rate limiting to API (feature, ready)
+- #11 Database migration fails on empty tables (bug, ready)
+
+### P2 — Medium
+- #3 Refactor config loader (refactor, needs-triage)
+
+### Unprioritized
+- #14 Update README examples (task)
+
+**Total**: 5 open issues
+```
+
+### `new`
+
+Create a new GitHub issue interactively:
+
+1. Ask the user for:
+   - **Title** (required)
+   - **Type** — bug, feature, task, chore, or refactor (maps to label)
+   - **Priority** — P0-P3 (maps to label)
+   - **Description** (required)
+   - **Acceptance criteria** (optional)
+2. Create with `gh issue create --title "..." --body "..." --label "type,priority,needs-triage"`
+3. Report the issue URL.
+
+### `pick #N`
+
+Start working on issue #N:
+
+1. Run `gh issue view N` to get the issue details.
+2. Create a branch: `git checkout -b <type>/<N>-<short-title>` (derive type from label, slugify the title).
+3. Add `in-progress` label, remove `ready` label: `gh issue edit N --add-label "in-progress" --remove-label "ready"`
+4. Write the issue description and acceptance criteria into `tasks/todo.md` as a plan.
+5. Present the plan and ask the user to confirm before starting implementation.
+
+### `close #N`
+
+Close issue #N:
+
+1. Run `gh issue view N` to get context.
+2. Ask the user for a brief summary of what was done.
+3. Add a closing comment with the summary: `gh issue comment N --body "..."`
+4. Close the issue: `gh issue close N --reason completed`
+5. Remove `in-progress` label if present.
+
+## Rules
+
+- Always show issue numbers so the user can reference them.
+- If `gh` is not available or not authenticated, say so and suggest `gh auth login`.
+- For `pick`, always verify there are no uncommitted changes before creating a branch.
+- For `pick`, use the branch naming convention: `<type>/<issue-number>-<short-slug>` (e.g., `feat/8-rate-limiting`, `fix/12-auth-token`).
+- Keep `tasks/todo.md` as the working plan — issues are the backlog, todo.md is the active session plan.

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -44,6 +44,19 @@ Include the confidence score and a one-line assessment in the plan header:
 > Confidence: 0.85 — Architecture fit clear, but API behavior needs verification.
 ```
 
+## Milestone Prompt
+
+After writing the plan, if the plan has 2+ checkpoints, ask the user:
+
+> "This plan has [N] checkpoints. Would you like to create GitHub milestones for them?"
+
+If yes:
+1. Create milestones via `gh api repos/{owner}/{repo}/milestones` for each checkpoint.
+2. If issues exist for the work items, assign them to the appropriate milestone.
+3. Note the milestone names in `tasks/todo.md` next to each checkpoint.
+
+If `gh` is not available or the user declines, skip silently.
+
 ## Rules
 
 - Tasks under 3 steps: skip the plan, just execute. Still run the confidence check mentally.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,46 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Run '...'
+        2. See error '...'
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "Low — cosmetic or minor inconvenience"
+        - "Medium — broken feature with workaround"
+        - "High — broken feature, no workaround"
+        - "Critical — data loss, security, or system down"
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, language version, relevant tool versions.
+      placeholder: "e.g., macOS 14.5, Python 3.12, Claude Code 1.x"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,35 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["feature", "needs-triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What feature would you like?
+      placeholder: A clear description of the feature.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Why is this needed? What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How will we know this is done?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Estimated Scope
+      options:
+        - "Small — a few hours, single file"
+        - "Medium — a day or two, multiple files"
+        - "Large — a week+, architectural changes"

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,24 @@
+name: Task
+description: A development task or chore
+labels: ["task"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How will we know this is done?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Related issues, files, or background information.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## What
+
+<!-- What does this PR do? One sentence. -->
+
+## Why
+
+<!-- Why is this change needed? Link to issue if applicable. -->
+
+Closes #
+
+## How
+
+<!-- How was this implemented? Key decisions or tradeoffs. -->
+
+## Test Plan
+
+- [ ] Tests pass locally (`make check`)
+- [ ] New tests added for new functionality
+- [ ] Manual verification:
+  -
+
+## Checklist
+
+- [ ] Code follows project conventions
+- [ ] No secrets or credentials in diff
+- [ ] Documentation updated if needed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ If a user instruction contradicts this document, flag the conflict and ask which
 - **2.1** Never take irreversible actions (delete files, rm -rf, force-push, drop database, destructive commands) without **explicit user confirmation** — even if the task seems to require it.
 - **2.2 Git Safety**:
   - **NEVER commit to `main` directly.** Always create a feature branch first.
-  - Branch naming: `feat/short-description`, `fix/short-description`, `refactor/short-description`, `test/short-description`
+  - Branch naming: `feat/123-short-description`, `fix/45-short-description` (include issue number when working from an issue). Without an issue: `feat/short-description`, `fix/short-description`.
   - Commit messages: imperative tense, concise — e.g., `feat: add IOC extraction pipeline`, `fix: resolve null pointer in validator`
   - Workflow: branch → commit → push → PR. Use `gh pr merge --squash` for repos requiring squash merges.
   - After merge: `git checkout main && git pull --ff-only origin main`
@@ -210,6 +210,7 @@ The following slash commands are available via `.claude/skills/`:
 | `/plan <task>` | Create a structured plan with confidence assessment in `tasks/todo.md` |
 | `/review [scope]` | Review code changes with Four Questions validation |
 | `/test [tier]` | Run tests, analyze failures, propose fixes |
+| `/backlog [show\|new\|pick #N\|close #N]` | Manage GitHub issues backlog — view, pick, or create work items |
 | `/lesson <description>` | Record a lesson (mistake, positive pattern, troubleshooting, insight) |
 | `/checkpoint [message]` | Commit working state and update task tracking |
 | `/status` | Show current project progress and what's next |

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ endif
 # ---------------------------------------------------------------------------
 
 .PHONY: test test-unit test-integration test-agent test-file test-coverage \
-        lint fmt typecheck build check help
+        lint fmt typecheck build check setup-github help
 
 ## Run full test suite: unit → integration → agent (fail-fast)
 ## For Rust: cargo test runs all tests; tiers are filtered by test name prefix
@@ -250,6 +250,25 @@ build:
 check: lint typecheck test
 	@echo "✅ All checks passed — ready for PR."
 
+## Set up GitHub labels and project management
+setup-github:
+	@echo "═══ Setting up GitHub project management ═══"
+	@echo "Creating labels..."
+	@gh label create "bug" --color "d73a4a" --description "Something isn't working" --force 2>/dev/null || true
+	@gh label create "feature" --color "0075ca" --description "New feature or enhancement" --force 2>/dev/null || true
+	@gh label create "task" --color "0e8a16" --description "Development task or chore" --force 2>/dev/null || true
+	@gh label create "chore" --color "e4e669" --description "Maintenance or cleanup" --force 2>/dev/null || true
+	@gh label create "refactor" --color "d4c5f9" --description "Code restructuring, no behavior change" --force 2>/dev/null || true
+	@gh label create "P0-critical" --color "b60205" --description "Drop everything" --force 2>/dev/null || true
+	@gh label create "P1-high" --color "d93f0b" --description "Fix this sprint" --force 2>/dev/null || true
+	@gh label create "P2-medium" --color "fbca04" --description "Plan for next sprint" --force 2>/dev/null || true
+	@gh label create "P3-low" --color "c5def5" --description "Nice to have" --force 2>/dev/null || true
+	@gh label create "needs-triage" --color "f9d0c4" --description "Needs review and prioritization" --force 2>/dev/null || true
+	@gh label create "ready" --color "0e8a16" --description "Ready to be picked up" --force 2>/dev/null || true
+	@gh label create "blocked" --color "b60205" --description "Waiting on external dependency" --force 2>/dev/null || true
+	@gh label create "in-progress" --color "1d76db" --description "Currently being worked on" --force 2>/dev/null || true
+	@echo "✅ Labels created"
+
 ## Show available targets
 help:
 	@echo "Available targets:"
@@ -264,6 +283,7 @@ help:
 	@echo "  make typecheck         Run type checker"
 	@echo "  make build             Compile / build"
 	@echo "  make check             Lint + typecheck + full suite (pre-PR gate)"
+	@echo "  make setup-github      Create GitHub labels (requires gh CLI)"
 	@echo ""
 	@echo "Options:"
 	@echo "  LANG=python|typescript|go|rust  Override language detection"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Scaffolding solves this by giving Claude Code the right context from the very fi
 
 - **An agent constitution** (`CLAUDE.md`) that defines guardrails, planning workflow, testing tiers, subagent delegation, and recovery patterns — so Claude operates with senior-engineer standards instead of guessing.
 - **Pre-configured permissions** (`.claude/settings.json`) with a tiered model — safe operations auto-approved, destructive operations always gated, and middle-ground operations that you decide during init.
-- **10 slash commands** (`/plan`, `/review`, `/test`, `/lesson`, `/checkpoint`, `/status`, `/simplify`, `/index`, `/save`, `/load`) so common workflows are one command away.
+- **11 slash commands** (`/plan`, `/review`, `/test`, `/lesson`, `/checkpoint`, `/status`, `/simplify`, `/index`, `/save`, `/load`, `/backlog`) so common workflows are one command away.
 - **8 agent specifications** for subagent delegation — Plan, Research, Code Review, Test Runner, Build Validator, Code Architect, Code Simplifier, and Verify — each with defined context budgets and output contracts.
 - **A lessons-learned system** (`tasks/lessons.md`) that accumulates across sessions, so mistakes compound into preventive rules instead of being forgotten.
 - **Language-specific conventions** for Python, TypeScript, Go, and Rust that get appended to `CLAUDE.md` during init — best practices, linter configs, project structure, and testing patterns.
@@ -121,8 +121,11 @@ scaffolding/
 ├── CLAUDE.md                   # Agent constitution (with placeholders)
 ├── .claude/
 │   ├── settings.json           # Permission defaults
-│   ├── skills/                 # 10 slash commands
+│   ├── skills/                 # 11 slash commands
 │   └── hooks/                  # Main branch protection
+├── .github/
+│   ├── ISSUE_TEMPLATE/         # Bug, feature, task templates
+│   └── pull_request_template.md
 ├── agents/                     # 8 agent specs
 ├── tasks/                      # Plan, lessons, test registry, session state
 ├── tests/                      # Tier directories
@@ -139,8 +142,11 @@ my-api/
 ├── .claude/
 │   ├── settings.json           # Permissions from your choices
 │   ├── skills/                 # /plan, /review, /test, /lesson, /checkpoint, /status,
-│   │                           #   /simplify, /index, /save, /load
+│   │                           #   /simplify, /index, /save, /load, /backlog
 │   └── hooks/                  # protect-main-branch.sh
+├── .github/
+│   ├── ISSUE_TEMPLATE/         # Bug, feature, task issue forms
+│   └── pull_request_template.md
 ├── agents/                     # plan, research, code-review, test-runner, build-validator,
 │   └── *.md                    #   code-architect, code-simplifier, verify
 ├── tasks/
@@ -198,6 +204,7 @@ Language-specific conventions (Python, TypeScript, Go, Rust) are appended during
 | `/index` | Generate `PROJECT_INDEX.md` for fast session orientation |
 | `/save` | Snapshot session state to `tasks/session.md` |
 | `/load` | Restore context from previous session and orient |
+| `/backlog` | Manage GitHub issues — view, pick, create, close work items |
 
 ### Agents
 
@@ -275,6 +282,18 @@ Language-aware with auto-detection (Cargo.toml, go.mod, tsconfig.json, pyproject
 | `make typecheck` | Run type checker |
 | `make build` | Compile/build |
 | `make check` | lint + typecheck + test (pre-PR gate) |
+| `make setup-github` | Create issue labels (requires `gh` CLI) |
+
+### GitHub Project Management
+
+Scaffolding includes issue templates, a PR template, and label taxonomy to integrate with GitHub's project management features:
+
+- **Issue templates** (`.github/ISSUE_TEMPLATE/`) — form-based templates for bugs, features, and tasks with structured fields (severity, scope, acceptance criteria)
+- **PR template** (`.github/pull_request_template.md`) — standardized format with What/Why/How sections, test plan checklist, and issue linking
+- **Labels** — type labels (bug, feature, task, chore, refactor), priority labels (P0-critical through P3-low), and status labels (needs-triage, ready, blocked, in-progress). Created via `make setup-github` or during `./scaffold` init
+- **`/backlog` command** — bridges GitHub Issues with local task management. View open issues by priority, pick an issue to start working on (creates branch, sets labels, writes plan), create new issues, or close completed ones
+
+During `./scaffold` init, if the GitHub CLI is authenticated, you'll be prompted to create labels and optionally a GitHub Projects kanban board.
 
 ## Supported Languages
 
@@ -308,7 +327,7 @@ Language-aware with auto-detection (Cargo.toml, go.mod, tsconfig.json, pyproject
 ### Running Tests
 
 ```bash
-# All tests (7 suites, 272 assertions)
+# All tests (7 suites, 302 assertions)
 bash tests/test_scaffold.sh
 
 # Single language

--- a/scaffold
+++ b/scaffold
@@ -33,6 +33,8 @@ ALLOW_COMMIT=false
 ALLOW_PUSH=false
 ALLOW_PKG_MANAGER=false
 ALLOW_DOCKER=false
+SETUP_LABELS=false
+SETUP_KANBAN=false
 
 # Colors (disabled if not a terminal)
 if [[ -t 1 ]]; then
@@ -449,6 +451,126 @@ step_git_remote() {
 }
 
 # ---------------------------------------------------------------------------
+# Step 7: GitHub Project Management
+# ---------------------------------------------------------------------------
+step_github_pm() {
+  header "GitHub Project Management"
+
+  info "Issue templates and PR template are included in .github/"
+
+  if [[ -z "$GIT_REMOTE" ]]; then
+    info "No git remote set. Run 'make setup-github' when your remote is ready."
+    return
+  fi
+
+  if ! command -v gh &>/dev/null; then
+    info "GitHub CLI (gh) not found. Install it and run 'make setup-github' to set up labels."
+    return
+  fi
+
+  if ! gh auth status &>/dev/null 2>&1; then
+    info "GitHub CLI not authenticated. Run 'gh auth login' then 'make setup-github'."
+    return
+  fi
+
+  prompt_yn SETUP_LABELS "Create issue labels (type, priority, status)?" true
+  prompt_yn SETUP_KANBAN "Create a GitHub Projects kanban board?" false
+}
+
+extract_repo_from_remote() {
+  local url="$GIT_REMOTE"
+  # Handle SSH: git@github.com:user/repo.git
+  if [[ "$url" == git@github.com:* ]]; then
+    url="${url#git@github.com:}"
+    url="${url%.git}"
+    echo "$url"
+    return
+  fi
+  # Handle HTTPS: https://github.com/user/repo.git
+  if [[ "$url" == https://github.com/* ]]; then
+    url="${url#https://github.com/}"
+    url="${url%.git}"
+    echo "$url"
+    return
+  fi
+  echo ""
+}
+
+create_github_labels() {
+  info "Creating issue labels..."
+  local repo
+  repo="$(extract_repo_from_remote)"
+  if [[ -z "$repo" ]]; then
+    warn "Could not determine GitHub repo from remote URL."
+    return
+  fi
+
+  # Type labels
+  gh label create "bug" --color "d73a4a" --description "Something isn't working" --repo "$repo" --force 2>/dev/null || true
+  gh label create "feature" --color "0075ca" --description "New feature or enhancement" --repo "$repo" --force 2>/dev/null || true
+  gh label create "task" --color "0e8a16" --description "Development task or chore" --repo "$repo" --force 2>/dev/null || true
+  gh label create "chore" --color "e4e669" --description "Maintenance or cleanup" --repo "$repo" --force 2>/dev/null || true
+  gh label create "refactor" --color "d4c5f9" --description "Code restructuring, no behavior change" --repo "$repo" --force 2>/dev/null || true
+
+  # Priority labels
+  gh label create "P0-critical" --color "b60205" --description "Drop everything" --repo "$repo" --force 2>/dev/null || true
+  gh label create "P1-high" --color "d93f0b" --description "Fix this sprint" --repo "$repo" --force 2>/dev/null || true
+  gh label create "P2-medium" --color "fbca04" --description "Plan for next sprint" --repo "$repo" --force 2>/dev/null || true
+  gh label create "P3-low" --color "c5def5" --description "Nice to have" --repo "$repo" --force 2>/dev/null || true
+
+  # Status labels
+  gh label create "needs-triage" --color "f9d0c4" --description "Needs review and prioritization" --repo "$repo" --force 2>/dev/null || true
+  gh label create "ready" --color "0e8a16" --description "Ready to be picked up" --repo "$repo" --force 2>/dev/null || true
+  gh label create "blocked" --color "b60205" --description "Waiting on external dependency" --repo "$repo" --force 2>/dev/null || true
+  gh label create "in-progress" --color "1d76db" --description "Currently being worked on" --repo "$repo" --force 2>/dev/null || true
+
+  success "Labels created (type, priority, status)"
+}
+
+create_github_project() {
+  info "Creating GitHub Projects kanban board..."
+  local repo
+  repo="$(extract_repo_from_remote)"
+  local owner="${repo%%/*}"
+
+  local project_url
+  project_url="$(gh project create --title "${PROJECT_NAME}" --owner "$owner" 2>/dev/null)" || true
+
+  if [[ -n "$project_url" ]]; then
+    success "Kanban board created: $project_url"
+  else
+    warn "Could not create project board. Create one manually at https://github.com/${repo}/projects"
+  fi
+}
+
+apply_github_pm() {
+  if [[ "$SETUP_LABELS" != true && "$SETUP_KANBAN" != true ]]; then
+    return
+  fi
+
+  header "Setting Up GitHub Project Management"
+
+  # Push to remote first so labels can be created
+  if [[ -n "$GIT_REMOTE" ]]; then
+    info "Pushing to remote..."
+    git -C "$SCRIPT_DIR" push -u origin main 2>/dev/null || true
+  fi
+
+  if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null 2>&1; then
+    info "GitHub CLI not available. Run 'make setup-github' to create labels and project board."
+    return
+  fi
+
+  if [[ "$SETUP_LABELS" == true ]]; then
+    create_github_labels
+  fi
+
+  if [[ "$SETUP_KANBAN" == true ]]; then
+    create_github_project
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Apply: Template engine
 # ---------------------------------------------------------------------------
 apply_templates() {
@@ -620,7 +742,7 @@ make test
 This project is configured for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with:
 
 - Agent constitution (\`CLAUDE.md\`)
-- 10 slash commands: \`/plan\`, \`/review\`, \`/test\`, \`/lesson\`, \`/checkpoint\`, \`/status\`, \`/simplify\`, \`/index\`, \`/save\`, \`/load\`
+- 11 slash commands: \`/plan\`, \`/review\`, \`/test\`, \`/backlog\`, \`/lesson\`, \`/checkpoint\`, \`/status\`, \`/simplify\`, \`/index\`, \`/save\`, \`/load\`
 - 8 agent specifications in \`agents/\`
 - Task management in \`tasks/\`
 
@@ -775,11 +897,12 @@ show_summary() {
   echo "What's configured:"
   echo -e "  ${BOLD}CLAUDE.md${RESET}           Agent constitution + conventions"
   echo -e "  ${BOLD}.claude/settings${RESET}    Tiered permissions"
-  echo -e "  ${BOLD}.claude/skills/${RESET}     10 slash commands (/plan, /review, /save, /load, ...)"
+  echo -e "  ${BOLD}.claude/skills/${RESET}     11 slash commands (/plan, /review, /backlog, /save, /load, ...)"
   echo -e "  ${BOLD}.claude/hooks/${RESET}      Main branch protection"
+  echo -e "  ${BOLD}.github/${RESET}            Issue templates, PR template"
   echo -e "  ${BOLD}agents/${RESET}             8 agent specifications"
   echo -e "  ${BOLD}tasks/${RESET}              Plan, lessons, test registry"
-  echo -e "  ${BOLD}Makefile${RESET}            test, lint, fmt, typecheck, build, check"
+  echo -e "  ${BOLD}Makefile${RESET}            test, lint, fmt, typecheck, build, check, setup-github"
 
   if [[ "$LANGUAGE" != "none" ]]; then
     echo -e "  ${BOLD}Language${RESET}            $LANGUAGE (conventions, configs, tooling)"
@@ -821,10 +944,12 @@ main() {
   step_ralph
   step_planning
   step_git_remote
+  step_github_pm
 
   apply_templates
   cleanup_artifacts
   init_git
+  apply_github_pm
   show_summary
 }
 

--- a/tasks/tests.md
+++ b/tasks/tests.md
@@ -9,7 +9,7 @@
 
 | Command | Scope | When to Use |
 |---------|-------|-------------|
-| `bash tests/test_scaffold.sh` | All scaffold behavior tests (7 suites, 272 assertions) | Before PR, after scaffold changes |
+| `bash tests/test_scaffold.sh` | All scaffold behavior tests (7 suites, 302 assertions) | Before PR, after scaffold changes |
 | `bash tests/test_scaffold.sh python` | Single language test | Debugging specific language scaffold |
 | `bash tests/test_scaffold.sh keep` | --keep flag test | After changes to cleanup logic |
 | `bash tests/test_scaffold.sh permissions` | Permissions test | After changes to permission logic |
@@ -26,7 +26,7 @@
 
 | Module / Component | Unit | Integration | Agent Behavior | Priority Gap |
 |-------------------|------|-------------|----------------|--------------|
-| scaffold (init script) | ❌ 0 | ✅ 272 (7 suites) | ❌ 0 | LOW |
+| scaffold (init script) | ❌ 0 | ✅ 302 (7 suites) | ❌ 0 | LOW |
 | .claude/hooks/protect-main-branch.sh | ❌ 0 | ❌ 0 | ❌ 0 | MEDIUM |
 | .claude/skills/ | ❌ 0 | ❌ 0 | ❌ 0 | LOW |
 

--- a/tests/test_scaffold.sh
+++ b/tests/test_scaffold.sh
@@ -135,6 +135,7 @@ setup_test() {
   WORK_DIR="$(mktemp -d "/tmp/scaffold-test-${test_name}-XXXXXX")"
   cp -r "$SCRIPT_DIR"/* "$WORK_DIR/" 2>/dev/null || true
   cp -r "$SCRIPT_DIR"/.claude "$WORK_DIR/" 2>/dev/null || true
+  cp -r "$SCRIPT_DIR"/.github "$WORK_DIR/" 2>/dev/null || true
   cp -r "$SCRIPT_DIR"/.gitignore "$WORK_DIR/" 2>/dev/null || true
   # Don't copy .git — scaffold creates its own
 }
@@ -185,7 +186,15 @@ assert_common_structure() {
   assert_file_exists ".claude/skills/index/SKILL.md"
   assert_file_exists ".claude/skills/save/SKILL.md"
   assert_file_exists ".claude/skills/load/SKILL.md"
+  assert_file_exists ".claude/skills/backlog/SKILL.md"
   assert_file_exists ".claude/hooks/protect-main-branch.sh"
+
+  # GitHub templates
+  assert_file_exists ".github/ISSUE_TEMPLATE/bug.yml"
+  assert_file_exists ".github/ISSUE_TEMPLATE/feature.yml"
+  assert_file_exists ".github/ISSUE_TEMPLATE/task.yml"
+  assert_file_exists ".github/ISSUE_TEMPLATE/config.yml"
+  assert_file_exists ".github/pull_request_template.md"
 
   # Agents
   assert_dir_exists "agents"


### PR DESCRIPTION
## What

Add GitHub project management integration — issue templates, PR template, label taxonomy, `/backlog` command, and milestone support.

## Why

Bridges GitHub Issues with local task management (`tasks/todo.md`) so Claude Code can effectively manage work items, track priorities, and maintain project state across sessions.

Closes the gap identified in the project management audit — scaffolding had no issue templates, labels, or workflow for managing a backlog.

## How

- **Issue templates** (`.github/ISSUE_TEMPLATE/`): YAML form-based templates for bugs, features, and tasks with structured fields
- **PR template** (`.github/pull_request_template.md`): What/Why/How format with test plan checklist
- **Label taxonomy**: Type (bug, feature, task, chore, refactor), Priority (P0-P3), Status (needs-triage, ready, blocked, in-progress) — created via `make setup-github` or during scaffold init
- **`/backlog` command**: View issues by priority, pick an issue (creates branch + sets labels + writes plan), create new issues, close completed ones
- **`/plan` milestone prompt**: After writing a plan with 2+ checkpoints, offers to create GitHub milestones
- **Scaffold integration**: `step_github_pm()` asks about labels and kanban during init when `gh` CLI is available

## Test Plan

- [x] Tests pass locally (`bash tests/test_scaffold.sh` — 302/302 assertions)
- [x] New assertions for all `.github/` files and `/backlog` skill
- [x] All 5 language scaffolds + keep + permissions suites pass
- [ ] Manual verification:
  - Issue templates render correctly on GitHub
  - `make setup-github` creates labels
  - `/backlog show` lists issues by priority

## Checklist

- [x] Code follows project conventions
- [x] No secrets or credentials in diff
- [x] Documentation updated (README, CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)