### PR TITLE
chore: rename project from scaffolding to scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # =============================================================================
-# Scaffolding — .gitignore
+# Scaffold — .gitignore
 # =============================================================================
 # Language-specific entries are appended during scaffold init.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scaffolding
+# Scaffold
 
 A project template and CLI for bootstrapping repositories optimized for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 
@@ -8,7 +8,7 @@ Clone it, run `./scaffold`, and get a fully configured project with an agent con
 
 Starting a new project with Claude Code usually means spending your first few sessions teaching it how you want to work — your commit conventions, testing expectations, when to plan vs. just build, what's safe to auto-approve. That setup is repetitive and easy to get wrong.
 
-Scaffolding solves this by giving Claude Code the right context from the very first session:
+Scaffold solves this by giving Claude Code the right context from the very first session:
 
 - **An agent constitution** (`CLAUDE.md`) that defines guardrails, planning workflow, testing tiers, subagent delegation, and recovery patterns — so Claude operates with senior-engineer standards instead of guessing.
 - **Pre-configured permissions** (`.claude/settings.json`) with a tiered model — safe operations auto-approved, destructive operations always gated, and middle-ground operations that you decide during init.
@@ -37,13 +37,13 @@ claude
 ### Option B: Git Clone
 
 ```bash
-git clone https://github.com/sakebomb/scaffolding.git my-project
+git clone https://github.com/sakebomb/scaffold.git my-project
 cd my-project
 ./scaffold
 claude
 ```
 
-The scaffold script detects the cloned scaffolding history and reinitializes git automatically.
+The scaffold script detects the cloned scaffold history and reinitializes git automatically.
 
 Once inside Claude Code, type `/start` for a guided walkthrough, or see `GETTING_STARTED.md` for the full onboarding guide.
 
@@ -53,7 +53,7 @@ Running `./scaffold` walks you through an interactive setup:
 
 ```
 ╔═══════════════════════════════════════════════════╗
-║         Scaffolding — Claude Code Setup          ║
+║          Scaffold — Claude Code Setup            ║
 ╚═══════════════════════════════════════════════════╝
 
 ═══ Project Setup ═══
@@ -117,7 +117,7 @@ By default, the `scaffold` script and `templates/` directory are removed after i
 **Before** (what you clone):
 
 ```
-scaffolding/
+scaffold/
 ├── scaffold                    # Init script (removed after init)
 ├── templates/                  # Language configs (removed after init)
 │   ├── python/                 #   CONVENTIONS.md, pyproject.toml.tmpl, ruff.toml, ...
@@ -312,7 +312,7 @@ Language-aware with auto-detection (Cargo.toml, go.mod, tsconfig.json, pyproject
 
 ### GitHub Project Management
 
-Scaffolding includes issue templates, a PR template, and label taxonomy to integrate with GitHub's project management features:
+Scaffold includes issue templates, a PR template, and label taxonomy to integrate with GitHub's project management features:
 
 - **Issue templates** (`.github/ISSUE_TEMPLATE/`) — form-based templates for bugs, features, and tasks with structured fields (severity, scope, acceptance criteria)
 - **PR template** (`.github/pull_request_template.md`) — standardized format with What/Why/How sections, test plan checklist, and issue linking
@@ -348,14 +348,14 @@ When enabled during `./scaffold` init, adds production-ready Docker support:
 
 ### Updating Existing Projects
 
-If scaffolding improves after you've already scaffolded a project, you can pull updates:
+If scaffold improves after you've already scaffolded a project, you can pull updates:
 
 ```bash
 # Requires the scaffold script (use --keep during init, or re-download)
 ./scaffold --update
 ```
 
-This compares your `.claude/skills/`, `.claude/hooks/`, and `agents/` against the latest from the scaffolding repo, shows a diff, and applies changes with your confirmation.
+This compares your `.claude/skills/`, `.claude/hooks/`, and `agents/` against the latest from the scaffold repo, shows a diff, and applies changes with your confirmation.
 
 ## Supported Languages
 
@@ -407,7 +407,7 @@ bash tests/test_scaffold.sh permissions
 ### Project Structure for Contributors
 
 ```
-scaffolding/
+scaffold/
 ├── scaffold                    # Main init script (bash)
 ├── templates/                  # Language templates + Ralph Wiggum
 ├── .claude/                    # Claude Code configuration

--- a/scaffold
+++ b/scaffold
@@ -133,14 +133,14 @@ prompt_choice() {
 # Parse CLI flags
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
-# Update mode — pull latest skills, agents, hooks from scaffolding repo
+# Update mode — pull latest skills, agents, hooks from scaffold repo
 # ---------------------------------------------------------------------------
-SCAFFOLDING_REPO="https://raw.githubusercontent.com/sakebomb/scaffolding/main"
+SCAFFOLD_REPO="https://raw.githubusercontent.com/sakebomb/scaffold/main"
 
 run_update() {
-  header "Scaffolding Update"
+  header "Scaffold Update"
 
-  info "Checking for updates from scaffolding repo..."
+  info "Checking for updates from scaffold repo..."
   echo ""
 
   if ! command -v curl &>/dev/null; then
@@ -171,7 +171,7 @@ run_update() {
   trap 'rm -rf "$tmp_dir"' EXIT
 
   for rel_path in "${update_files[@]}"; do
-    local url="$SCAFFOLDING_REPO/$rel_path"
+    local url="$SCAFFOLD_REPO/$rel_path"
     local tmp_file="$tmp_dir/$rel_path"
     mkdir -p "$(dirname "$tmp_file")"
 
@@ -270,7 +270,7 @@ Options:
   --help, -h          Show this help message
   --keep              Don't remove scaffold artifacts after init
   --non-interactive   Use defaults for all prompts (for CI/automation)
-  --update            Update skills, agents, and hooks from scaffolding repo
+  --update            Update skills, agents, and hooks from scaffold repo
 
 What it does:
   1. Asks for project name, description, and language
@@ -807,7 +807,7 @@ RUST
     success "Ralph Wiggum installed (scripts/ralph-loop.sh)"
   fi
 
-  # --- Generate project README (replaces scaffolding README) ---
+  # --- Generate project README (replaces scaffold README) ---
   info "Generating project README..."
   local getting_started=""
   case "$LANGUAGE" in
@@ -1082,7 +1082,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- Initial project setup with scaffolding framework
+- Initial project setup with scaffold framework
 CHLOG
   success "CHANGELOG.md generated"
 
@@ -1407,12 +1407,12 @@ cleanup_artifacts() {
 init_git() {
   header "Git Initialization"
 
-  # If cloned from scaffolding repo, remove the cloned .git to start fresh
+  # If cloned from scaffold repo, remove the cloned .git to start fresh
   if [[ -d "$SCRIPT_DIR/.git" ]]; then
     local remote_url
     remote_url="$(git -C "$SCRIPT_DIR" remote get-url origin 2>/dev/null || echo "")"
-    if [[ "$remote_url" == *"sakebomb/scaffolding"* ]]; then
-      info "Removing cloned scaffolding git history..."
+    if [[ "$remote_url" == *"sakebomb/scaffold"* ]]; then
+      info "Removing cloned scaffold git history..."
       rm -rf "$SCRIPT_DIR/.git"
     fi
   fi
@@ -1437,7 +1437,7 @@ init_git() {
   info "Creating initial commit..."
   git -C "$SCRIPT_DIR" add -A
   git -C "$SCRIPT_DIR" commit -m "$(cat <<'EOF'
-feat: initialize project with scaffolding framework
+feat: initialize project with scaffold framework
 
 - CLAUDE.md agent constitution with project conventions
 - .claude/ settings, skills (slash commands), and hooks
@@ -1446,7 +1446,7 @@ feat: initialize project with scaffolding framework
 - Agent specifications
 - Language-aware Makefile
 
-Scaffolded with https://github.com/sakebomb/scaffolding
+Scaffolded with https://github.com/sakebomb/scaffold
 EOF
   )"
   success "Initial commit created"
@@ -1517,7 +1517,7 @@ main() {
 
   echo ""
   echo -e "${BOLD}╔═══════════════════════════════════════════════════╗${RESET}"
-  echo -e "${BOLD}║         Scaffolding — Claude Code Setup          ║${RESET}"
+  echo -e "${BOLD}║          Scaffold — Claude Code Setup            ║${RESET}"
   echo -e "${BOLD}╚═══════════════════════════════════════════════════╝${RESET}"
 
   step_project_basics

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -11,7 +11,7 @@ Add 9 features that harden scaffolded projects for real-world use: CI workflows,
 ## Plan
 
 ### Phase 1: CI Workflows — items #1, #4
-- [x] 1. Create `.github/workflows/ci.yml` for scaffolding repo itself
+- [x] 1. Create `.github/workflows/ci.yml` for scaffold repo itself
 - [x] 2. Add CI template generation to scaffold — per-language setup
 - [x] 3. Add test assertions for generated CI workflow
 


### PR DESCRIPTION
## Summary
- Renamed GitHub repo from `sakebomb/scaffolding` to `sakebomb/scaffold`
- Updated all internal references: URLs, comments, banners, help text, git remote
- CLI command (`./scaffold`) and project name now match — one name for everything

## What Changed
- `scaffold` — updated raw GitHub URLs, banner text, comments, help text, commit message template, git clone detection
- `README.md` — updated title, clone URL, tree diagrams, all prose references
- `.gitignore` — updated header comment
- `tasks/todo.md` — updated completed task description

## Test plan
- [x] Full test suite: 347/347 passing
- [x] No functional changes — naming only

🤖 Generated with [Claude Code](https://claude.com/claude-code)