### PR TITLE
feat: add --dry-run, make setup, and project archetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Running `./scaffold` walks you through an interactive setup:
   4) rust      — cargo test, clippy
   5) none      — language-agnostic (configure later)
 
+═══ Project Archetype ═══
+? Select project archetype:
+  1) none      — blank project (just language tooling)
+  2) cli       — command-line tool with argument parsing
+  3) api       — web API with routes and health check
+  4) library   — reusable library with public API
+
 ═══ Claude Code Permissions ═══
 ? Auto-approve git commit? [Y/n]: y
 ? Auto-approve git push? [y/N]: n
@@ -102,7 +109,15 @@ For automation or CI:
 ./scaffold --non-interactive
 ```
 
-Defaults: directory name as project name, python language, safe permissions only, no Ralph Wiggum, blank plan template.
+Defaults: directory name as project name, python language, no archetype, safe permissions only, no Ralph Wiggum, blank plan template.
+
+### Dry Run
+
+Preview what scaffold would create without writing anything:
+
+```bash
+./scaffold --non-interactive --dry-run
+```
 
 ### Keeping Scaffold Artifacts
 
@@ -308,6 +323,7 @@ Language-aware with auto-detection (Cargo.toml, go.mod, tsconfig.json, pyproject
 | `make typecheck` | Run type checker |
 | `make build` | Compile/build |
 | `make check` | lint + typecheck + test (pre-PR gate) |
+| `make setup` | Bootstrap dev environment (deps + pre-commit) |
 | `make setup-github` | Create issue labels (requires `gh` CLI) |
 
 ### GitHub Project Management
@@ -367,6 +383,19 @@ This compares your `.claude/skills/`, `.claude/hooks/`, and `agents/` against th
 | Rust | clippy | rustfmt | (built-in) | cargo test | Cargo.toml |
 | None | — | — | — | — | (configure manually later) |
 
+## Project Archetypes
+
+After selecting a language, scaffold asks for a project archetype that generates deeper structure:
+
+| Archetype | What It Generates |
+|-----------|------------------|
+| **CLI** | Entry point with argument parsing and subcommand structure |
+| **API** | HTTP server with routes directory and health check endpoint |
+| **Library** | Public module with exported functions, ready for distribution |
+| **None** | Blank project with language tooling only (default) |
+
+Each archetype is language-aware — a Python API uses stdlib `http.server`, a Go API uses `net/http`, a Rust CLI uses `std::env`, etc. No framework dependencies are added by default.
+
 ## Contributing
 
 ### How to Contribute
@@ -389,7 +418,7 @@ This compares your `.claude/skills/`, `.claude/hooks/`, and `agents/` against th
 ### Running Tests
 
 ```bash
-# All tests (7 suites, 347 assertions)
+# All tests (12 suites, 614 assertions)
 bash tests/test_scaffold.sh
 
 # Single language
@@ -418,7 +447,7 @@ scaffold/
 ├── agents/                     # Agent specifications
 ├── tasks/                      # Plan, lessons, test registry
 ├── tests/
-│   └── test_scaffold.sh        # Behavior tests (317 assertions)
+│   └── test_scaffold.sh        # Behavior tests (614 assertions)
 └── CLAUDE.md                   # Agent constitution (with placeholders)
 ```
 

--- a/scaffold
+++ b/scaffold
@@ -15,6 +15,7 @@
 #   ./scaffold --help           Show help
 #   ./scaffold --keep           Don't remove scaffold artifacts after init
 #   ./scaffold --non-interactive Use defaults for all prompts
+#   ./scaffold --dry-run        Preview what would be created
 # =============================================================================
 set -euo pipefail
 
@@ -24,6 +25,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KEEP_ARTIFACTS=false
 NON_INTERACTIVE=false
+DRY_RUN=false
 PROJECT_NAME=""
 PROJECT_DESC=""
 LANGUAGE=""
@@ -36,6 +38,7 @@ ALLOW_DOCKER=false
 SETUP_LABELS=false
 SETUP_KANBAN=false
 ENABLE_DOCKER=false
+ARCHETYPE="none"
 
 # Colors (disabled if not a terminal)
 if [[ -t 1 ]]; then
@@ -246,6 +249,10 @@ parse_flags() {
         NON_INTERACTIVE=true
         shift
         ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
       --update)
         run_update
         exit 0
@@ -270,13 +277,15 @@ Options:
   --help, -h          Show this help message
   --keep              Don't remove scaffold artifacts after init
   --non-interactive   Use defaults for all prompts (for CI/automation)
+  --dry-run           Preview what would be created without writing anything
   --update            Update skills, agents, and hooks from scaffold repo
 
 What it does:
-  1. Asks for project name, description, and language
+  1. Asks for project name, description, language, and archetype
   2. Configures Claude Code permissions based on your preferences
   3. Sets up language-specific tooling (linter, formatter, test runner)
-  4. Optionally integrates Ralph Wiggum autonomous loop
+  4. Generates archetype structure (CLI, API, or library starter files)
+  5. Optionally integrates Ralph Wiggum autonomous loop
   5. Helps you create or load a project plan
   6. Initializes git with a clean first commit
   7. Removes scaffold artifacts (unless --keep is used)
@@ -290,6 +299,128 @@ Non-interactive defaults:
   Ralph Wiggum:    disabled
   Project plan:    template only
 HELP
+}
+
+# ---------------------------------------------------------------------------
+# Dry-run report — show what would be created without writing anything
+# ---------------------------------------------------------------------------
+dry_run_report() {
+  echo ""
+  header "Dry Run Preview"
+  echo ""
+  echo -e "  ${BOLD}Project:${RESET}     $PROJECT_NAME"
+  echo -e "  ${BOLD}Description:${RESET} $PROJECT_DESC"
+  echo -e "  ${BOLD}Language:${RESET}    $LANGUAGE"
+  echo -e "  ${BOLD}Archetype:${RESET}  $ARCHETYPE"
+  echo -e "  ${BOLD}Docker:${RESET}      $ENABLE_DOCKER"
+  echo -e "  ${BOLD}Ralph:${RESET}       $ENABLE_RALPH"
+  echo ""
+  echo -e "${BOLD}Files that would be created:${RESET}"
+  echo ""
+
+  # Common files (always created)
+  echo "  CLAUDE.md"
+  echo "  README.md"
+  echo "  GETTING_STARTED.md"
+  echo "  LICENSE"
+  echo "  Makefile"
+  echo "  .gitignore"
+  echo "  .env.example"
+  echo "  CHANGELOG.md"
+  echo "  .pre-commit-config.yaml"
+  echo "  .claude/settings.json"
+  echo "  .claude/hooks/protect-main-branch.sh"
+
+  # Skills
+  local skills=(plan review test lesson checkpoint status simplify index save load backlog doctor start)
+  for s in "${skills[@]}"; do
+    echo "  .claude/skills/$s/SKILL.md"
+  done
+
+  # GitHub
+  echo "  .github/ISSUE_TEMPLATE/bug.yml"
+  echo "  .github/ISSUE_TEMPLATE/feature.yml"
+  echo "  .github/ISSUE_TEMPLATE/task.yml"
+  echo "  .github/ISSUE_TEMPLATE/config.yml"
+  echo "  .github/pull_request_template.md"
+  echo "  .github/workflows/ci.yml"
+  echo "  .github/workflows/release.yml"
+
+  # Agents
+  local agents=(plan-agent research-agent code-review-agent test-runner-agent build-validator-agent code-architect-agent code-simplifier-agent verify-agent)
+  echo "  agents/README.md"
+  for a in "${agents[@]}"; do
+    echo "  agents/$a.md"
+  done
+
+  # Tasks
+  echo "  tasks/todo.md"
+  echo "  tasks/lessons.md"
+  echo "  tasks/tests.md"
+  echo "  tasks/session.md"
+
+  # Test dirs
+  echo "  tests/unit/"
+  echo "  tests/integration/"
+  echo "  tests/agent/"
+  echo "  scratch/.gitkeep"
+
+  # Language-specific files
+  local pkg_name="${PROJECT_NAME//-/_}"
+  case "$LANGUAGE" in
+    python)
+      echo "  pyproject.toml"
+      echo "  ruff.toml"
+      echo "  conftest.py"
+      echo "  src/${pkg_name}/__init__.py"
+      case "$ARCHETYPE" in
+        cli)      echo "  src/${pkg_name}/cli.py"; echo "  src/${pkg_name}/__main__.py" ;;
+        api)      echo "  src/${pkg_name}/app.py"; echo "  src/${pkg_name}/routes/health.py" ;;
+        library)  echo "  src/${pkg_name}/lib.py" ;;
+      esac
+      ;;
+    typescript)
+      echo "  package.json"
+      echo "  tsconfig.json"
+      echo "  eslint.config.mjs"
+      case "$ARCHETYPE" in
+        cli)      echo "  src/cli.ts" ;;
+        api)      echo "  src/app.ts"; echo "  src/routes/health.ts" ;;
+        *)        echo "  src/index.ts" ;;
+      esac
+      ;;
+    go)
+      echo "  go.mod"
+      case "$ARCHETYPE" in
+        api)      echo "  cmd/${PROJECT_NAME}/main.go"; echo "  internal/routes/health.go" ;;
+        library)  echo "  ${pkg_name}.go" ;;
+        *)        echo "  cmd/${PROJECT_NAME}/main.go" ;;
+      esac
+      ;;
+    rust)
+      echo "  Cargo.toml"
+      case "$ARCHETYPE" in
+        library)  echo "  src/lib.rs" ;;
+        *)        echo "  src/main.rs" ;;
+      esac
+      ;;
+  esac
+
+  # Docker
+  if [[ "$ENABLE_DOCKER" == true ]]; then
+    echo "  Dockerfile"
+    echo "  docker-compose.yml"
+  fi
+
+  # Ralph
+  if [[ "$ENABLE_RALPH" == true ]]; then
+    echo "  scripts/ralph-loop.sh"
+    echo "  PROMPT_build.md"
+    echo "  PROMPT_plan.md"
+  fi
+
+  echo ""
+  echo -e "${GREEN}No files were written. Run without --dry-run to scaffold.${RESET}"
 }
 
 # ---------------------------------------------------------------------------
@@ -355,6 +486,36 @@ step_language() {
         info "${DIM}Run: cargo build${RESET}"
         ;;
     esac
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Step 2b: Project archetype
+# ---------------------------------------------------------------------------
+step_archetype() {
+  # Skip if no language selected — archetypes need language context
+  if [[ "$LANGUAGE" == "none" ]]; then
+    return
+  fi
+
+  header "Project Archetype"
+
+  info "Choose an archetype to generate starter project structure."
+  info "  This creates entry points, routes, or module layout based on your project type."
+  echo ""
+
+  prompt_choice ARCHETYPE "Select project archetype:" \
+    "none      — blank project (just language tooling)" \
+    "cli       — command-line tool with argument parsing" \
+    "api       — web API with routes and health check" \
+    "library   — reusable library with public API"
+
+  ARCHETYPE="${ARCHETYPE%% *}"
+
+  if [[ "$ARCHETYPE" == "none" ]]; then
+    info "No archetype selected. Starting with a blank project."
+  else
+    success "Archetype: $ARCHETYPE"
   fi
 }
 
@@ -688,6 +849,502 @@ apply_github_pm() {
 }
 
 # ---------------------------------------------------------------------------
+# Apply: Archetype-specific project structure
+# ---------------------------------------------------------------------------
+apply_archetype() {
+  local escaped_name="$1"
+  local pkg_name="${PROJECT_NAME//-/_}"
+
+  info "Creating project structure (archetype: $ARCHETYPE)..."
+
+  case "$LANGUAGE" in
+    python)
+      mkdir -p "$SCRIPT_DIR/src/$pkg_name"
+      touch "$SCRIPT_DIR/src/$pkg_name/__init__.py"
+
+      case "$ARCHETYPE" in
+        cli)
+          cat > "$SCRIPT_DIR/src/$pkg_name/__main__.py" <<PYEOF
+"""Allow running as: python -m $pkg_name"""
+from ${pkg_name}.cli import main
+
+if __name__ == "__main__":
+    main()
+PYEOF
+          cat > "$SCRIPT_DIR/src/$pkg_name/cli.py" <<'PYEOF'
+"""Command-line interface for {{PROJECT_NAME}}."""
+import argparse
+import sys
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="{{PROJECT_NAME}}",
+        description="{{PROJECT_DESC}}",
+    )
+    parser.add_argument("--version", action="version", version="%(prog)s 0.1.0")
+
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # Example subcommand — replace with your own
+    run_parser = subparsers.add_parser("run", help="Run the main task")
+    run_parser.add_argument("target", nargs="?", default="world", help="Target to process")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        sys.exit(0)
+
+    if args.command == "run":
+        print(f"Running with target: {args.target}")
+PYEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/$pkg_name/cli.py"
+          sed -i "s/{{PROJECT_DESC}}/${PROJECT_DESC//\//\\/}/g" "$SCRIPT_DIR/src/$pkg_name/cli.py"
+          success "  Created CLI archetype: src/$pkg_name/cli.py, __main__.py"
+          ;;
+        api)
+          mkdir -p "$SCRIPT_DIR/src/$pkg_name/routes"
+          touch "$SCRIPT_DIR/src/$pkg_name/routes/__init__.py"
+          cat > "$SCRIPT_DIR/src/$pkg_name/app.py" <<'PYEOF'
+"""{{PROJECT_NAME}} — API application."""
+from http.server import HTTPServer
+
+from {{PKG_NAME}}.routes.health import HealthHandler
+
+
+def create_app(host: str = "0.0.0.0", port: int = 8000) -> HTTPServer:
+    """Create and return the HTTP server."""
+    server = HTTPServer((host, port), HealthHandler)
+    return server
+
+
+def main() -> None:
+    """Start the development server."""
+    server = create_app()
+    print(f"Server running on http://localhost:{server.server_address[1]}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()
+PYEOF
+          cat > "$SCRIPT_DIR/src/$pkg_name/routes/health.py" <<'PYEOF'
+"""Health check endpoint."""
+import json
+from http.server import BaseHTTPRequestHandler
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    """Handle HTTP requests."""
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            self._json_response(200, {"status": "ok"})
+        else:
+            self._json_response(404, {"error": "not found"})
+
+    def _json_response(self, status: int, body: dict) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+PYEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/$pkg_name/app.py"
+          sed -i "s/{{PKG_NAME}}/${pkg_name}/g" "$SCRIPT_DIR/src/$pkg_name/app.py"
+          success "  Created API archetype: src/$pkg_name/app.py, routes/health.py"
+          ;;
+        library)
+          cat > "$SCRIPT_DIR/src/$pkg_name/lib.py" <<'PYEOF'
+"""{{PROJECT_NAME}} — public API."""
+
+
+def hello(name: str = "world") -> str:
+    """Return a greeting. Replace with your library's public API."""
+    return f"Hello, {name}!"
+PYEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/$pkg_name/lib.py"
+          success "  Created library archetype: src/$pkg_name/lib.py"
+          ;;
+        *)
+          success "  Created src/$pkg_name/"
+          ;;
+      esac
+      ;;
+
+    typescript)
+      mkdir -p "$SCRIPT_DIR/src"
+
+      case "$ARCHETYPE" in
+        cli)
+          cat > "$SCRIPT_DIR/src/cli.ts" <<'TSEOF'
+/**
+ * CLI entry point for {{PROJECT_NAME}}.
+ */
+
+interface ParsedArgs {
+  command: string | null;
+  target: string;
+  flags: Record<string, boolean>;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const args = argv.slice(2);
+  const flags: Record<string, boolean> = {};
+  const positional: string[] = [];
+
+  for (const arg of args) {
+    if (arg.startsWith("--")) {
+      flags[arg.slice(2)] = true;
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return {
+    command: positional[0] ?? null,
+    target: positional[1] ?? "world",
+    flags,
+  };
+}
+
+function main(): void {
+  const { command, target, flags } = parseArgs(process.argv);
+
+  if (flags.version) {
+    console.log("{{PROJECT_NAME}} 0.1.0");
+    return;
+  }
+
+  if (flags.help || command === null) {
+    console.log("Usage: {{PROJECT_NAME}} <command> [target]");
+    console.log("");
+    console.log("Commands:");
+    console.log("  run [target]  Run the main task");
+    return;
+  }
+
+  if (command === "run") {
+    console.log(`Running with target: ${target}`);
+  }
+}
+
+main();
+TSEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/cli.ts"
+          success "  Created CLI archetype: src/cli.ts"
+          ;;
+        api)
+          mkdir -p "$SCRIPT_DIR/src/routes"
+          cat > "$SCRIPT_DIR/src/app.ts" <<'TSEOF'
+/**
+ * {{PROJECT_NAME}} — API application.
+ */
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import { healthHandler } from "./routes/health.js";
+
+const PORT = parseInt(process.env.PORT ?? "3000", 10);
+
+function router(req: IncomingMessage, res: ServerResponse): void {
+  if (req.url === "/health" && req.method === "GET") {
+    healthHandler(req, res);
+  } else {
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not found" }));
+  }
+}
+
+const server = createServer(router);
+
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});
+TSEOF
+          cat > "$SCRIPT_DIR/src/routes/health.ts" <<'TSEOF'
+/**
+ * Health check endpoint.
+ */
+import { IncomingMessage, ServerResponse } from "node:http";
+
+export function healthHandler(_req: IncomingMessage, res: ServerResponse): void {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ status: "ok" }));
+}
+TSEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/app.ts"
+          success "  Created API archetype: src/app.ts, src/routes/health.ts"
+          ;;
+        library)
+          cat > "$SCRIPT_DIR/src/index.ts" <<'TSEOF'
+/**
+ * {{PROJECT_NAME}} — public API.
+ */
+
+/**
+ * Return a greeting. Replace with your library's public API.
+ */
+export function hello(name: string = "world"): string {
+  return `Hello, ${name}!`;
+}
+TSEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/index.ts"
+          success "  Created library archetype: src/index.ts"
+          ;;
+        *)
+          cat > "$SCRIPT_DIR/src/index.ts" <<'TSEOF'
+export function main(): void {
+  console.log("Hello from {{PROJECT_NAME}}");
+}
+TSEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/index.ts"
+          success "  Created src/index.ts"
+          ;;
+      esac
+      ;;
+
+    go)
+      case "$ARCHETYPE" in
+        cli)
+          mkdir -p "$SCRIPT_DIR/cmd/$PROJECT_NAME"
+          cat > "$SCRIPT_DIR/cmd/$PROJECT_NAME/main.go" <<'GOEOF'
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(0)
+	}
+
+	switch os.Args[1] {
+	case "run":
+		target := "world"
+		if len(os.Args) > 2 {
+			target = os.Args[2]
+		}
+		fmt.Printf("Running with target: %s\n", target)
+	case "--version":
+		fmt.Println("{{PROJECT_NAME}} 0.1.0")
+	case "--help":
+		printUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1])
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Println("Usage: {{PROJECT_NAME}} <command> [target]")
+	fmt.Println("")
+	fmt.Println("Commands:")
+	fmt.Println("  run [target]  Run the main task")
+}
+GOEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/cmd/$PROJECT_NAME/main.go"
+          success "  Created CLI archetype: cmd/$PROJECT_NAME/main.go"
+          ;;
+        api)
+          mkdir -p "$SCRIPT_DIR/cmd/$PROJECT_NAME"
+          mkdir -p "$SCRIPT_DIR/internal/routes"
+          cat > "$SCRIPT_DIR/cmd/$PROJECT_NAME/main.go" <<'GOEOF'
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"{{PROJECT_NAME}}/internal/routes"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", routes.HealthHandler)
+
+	fmt.Printf("Server running on http://localhost:%s\n", port)
+	log.Fatal(http.ListenAndServe(":"+port, mux))
+}
+GOEOF
+          cat > "$SCRIPT_DIR/internal/routes/health.go" <<'GOEOF'
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// HealthHandler returns the health status of the service.
+func HealthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+GOEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/cmd/$PROJECT_NAME/main.go"
+          success "  Created API archetype: cmd/$PROJECT_NAME/main.go, internal/routes/health.go"
+          ;;
+        library)
+          cat > "$SCRIPT_DIR/${pkg_name}.go" <<'GOEOF'
+// Package {{PKG_NAME}} provides the public API.
+package {{PKG_NAME}}
+
+// Hello returns a greeting. Replace with your library's public API.
+func Hello(name string) string {
+	if name == "" {
+		name = "world"
+	}
+	return "Hello, " + name + "!"
+}
+GOEOF
+          sed -i "s/{{PKG_NAME}}/${pkg_name}/g" "$SCRIPT_DIR/${pkg_name}.go"
+          success "  Created library archetype: ${pkg_name}.go"
+          ;;
+        *)
+          mkdir -p "$SCRIPT_DIR/cmd/$PROJECT_NAME"
+          cat > "$SCRIPT_DIR/cmd/$PROJECT_NAME/main.go" <<'GOEOF'
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello from {{PROJECT_NAME}}")
+}
+GOEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/cmd/$PROJECT_NAME/main.go"
+          success "  Created cmd/$PROJECT_NAME/main.go"
+          ;;
+      esac
+      ;;
+
+    rust)
+      mkdir -p "$SCRIPT_DIR/src"
+
+      case "$ARCHETYPE" in
+        cli)
+          cat > "$SCRIPT_DIR/src/main.rs" <<'RSEOF'
+//! CLI entry point for {{PROJECT_NAME}}.
+use std::env;
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        print_usage();
+        process::exit(0);
+    }
+
+    match args[1].as_str() {
+        "run" => {
+            let target = args.get(2).map(|s| s.as_str()).unwrap_or("world");
+            println!("Running with target: {target}");
+        }
+        "--version" => println!("{{PROJECT_NAME}} 0.1.0"),
+        "--help" => print_usage(),
+        cmd => {
+            eprintln!("Unknown command: {cmd}");
+            process::exit(1);
+        }
+    }
+}
+
+fn print_usage() {
+    println!("Usage: {{PROJECT_NAME}} <command> [target]");
+    println!();
+    println!("Commands:");
+    println!("  run [target]  Run the main task");
+}
+RSEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/main.rs"
+          success "  Created CLI archetype: src/main.rs"
+          ;;
+        api)
+          cat > "$SCRIPT_DIR/src/main.rs" <<'RSEOF'
+//! {{PROJECT_NAME}} — API server.
+use std::io::Write;
+use std::net::TcpListener;
+
+fn main() {
+    let port = std::env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+    let addr = format!("0.0.0.0:{port}");
+    let listener = TcpListener::bind(&addr).expect("Failed to bind");
+    println!("Server running on http://localhost:{port}");
+
+    for stream in listener.incoming() {
+        if let Ok(mut stream) = stream {
+            let response = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"status\":\"ok\"}";
+            let _ = stream.write_all(response.as_bytes());
+        }
+    }
+}
+RSEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/main.rs"
+          success "  Created API archetype: src/main.rs"
+          ;;
+        library)
+          cat > "$SCRIPT_DIR/src/lib.rs" <<'RSEOF'
+//! {{PROJECT_NAME}} — public API.
+
+/// Return a greeting. Replace with your library's public API.
+pub fn hello(name: &str) -> String {
+    if name.is_empty() {
+        return "Hello, world!".to_string();
+    }
+    format!("Hello, {name}!")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hello_with_name() {
+        assert_eq!(hello("Rust"), "Hello, Rust!");
+    }
+
+    #[test]
+    fn test_hello_empty() {
+        assert_eq!(hello(""), "Hello, world!");
+    }
+}
+RSEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/lib.rs"
+          # Remove default main.rs for library archetype
+          success "  Created library archetype: src/lib.rs"
+          ;;
+        *)
+          cat > "$SCRIPT_DIR/src/main.rs" <<'RSEOF'
+fn main() {
+    println!("Hello from {{PROJECT_NAME}}");
+}
+RSEOF
+          sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/main.rs"
+          success "  Created src/main.rs"
+          ;;
+      esac
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
 # Apply: Template engine
 # ---------------------------------------------------------------------------
 apply_templates() {
@@ -747,49 +1404,8 @@ apply_templates() {
       success "  Updated .gitignore with $LANGUAGE entries"
     fi
 
-    # Create src directory
-    case "$LANGUAGE" in
-      python)
-        local pkg_name="${PROJECT_NAME//-/_}"
-        mkdir -p "$SCRIPT_DIR/src/$pkg_name"
-        touch "$SCRIPT_DIR/src/$pkg_name/__init__.py"
-        success "  Created src/$pkg_name/"
-        ;;
-      typescript)
-        mkdir -p "$SCRIPT_DIR/src"
-        cat > "$SCRIPT_DIR/src/index.ts" <<'TS'
-export function main(): void {
-  console.log("Hello from {{PROJECT_NAME}}");
-}
-TS
-        sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/index.ts"
-        success "  Created src/index.ts"
-        ;;
-      go)
-        mkdir -p "$SCRIPT_DIR/cmd/$PROJECT_NAME"
-        cat > "$SCRIPT_DIR/cmd/$PROJECT_NAME/main.go" <<'GO'
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("Hello from {{PROJECT_NAME}}")
-}
-GO
-        sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/cmd/$PROJECT_NAME/main.go"
-        success "  Created cmd/$PROJECT_NAME/main.go"
-        ;;
-      rust)
-        mkdir -p "$SCRIPT_DIR/src"
-        cat > "$SCRIPT_DIR/src/main.rs" <<'RUST'
-fn main() {
-    println!("Hello from {{PROJECT_NAME}}");
-}
-RUST
-        sed -i "s/{{PROJECT_NAME}}/${escaped_name}/g" "$SCRIPT_DIR/src/main.rs"
-        success "  Created src/main.rs"
-        ;;
-    esac
+    # Create src directory + archetype files
+    apply_archetype "$escaped_name"
   fi
 
   # --- Configure permissions ---
@@ -1473,7 +2089,7 @@ show_summary() {
   echo -e "  ${BOLD}.github/${RESET}            Issue templates, PR template, CI workflow"
   echo -e "  ${BOLD}agents/${RESET}             8 agent specifications"
   echo -e "  ${BOLD}tasks/${RESET}              Plan, lessons, test registry"
-  echo -e "  ${BOLD}Makefile${RESET}            test, lint, fmt, typecheck, build, check, setup-github"
+  echo -e "  ${BOLD}Makefile${RESET}            test, lint, fmt, typecheck, build, check, setup, setup-github"
   echo -e "  ${BOLD}.pre-commit${RESET}         Linting + secret scanning on commit"
 
   if [[ "$LANGUAGE" != "none" ]]; then
@@ -1491,8 +2107,9 @@ show_summary() {
   echo ""
   echo "Next steps:"
   echo "  1. cd $(basename "$SCRIPT_DIR")"
-  echo "  2. Start Claude Code: claude"
-  echo "  3. Type: /start"
+  echo "  2. Bootstrap dev environment: make setup"
+  echo "  3. Start Claude Code: claude"
+  echo "  4. Type: /start"
   echo ""
   echo -e "  ${DIM}Or skip /start and just tell Claude what to build:${RESET}"
   echo "  \"I want to build [your idea]. Help me create a plan.\""
@@ -1522,12 +2139,19 @@ main() {
 
   step_project_basics
   step_language
+  step_archetype
   step_permissions
   step_ralph
   step_docker
   step_planning
   step_git_remote
   step_github_pm
+
+  # Dry-run: show preview and exit without writing anything
+  if [[ "$DRY_RUN" == true ]]; then
+    dry_run_report
+    exit 0
+  fi
 
   apply_templates
   cleanup_artifacts

--- a/tasks/tests.md
+++ b/tasks/tests.md
@@ -9,9 +9,11 @@
 
 | Command | Scope | When to Use |
 |---------|-------|-------------|
-| `bash tests/test_scaffold.sh` | All scaffold behavior tests (7 suites, 347 assertions) | Before PR, after scaffold changes |
+| `bash tests/test_scaffold.sh` | All scaffold behavior tests (12 suites, 614 assertions) | Before PR, after scaffold changes |
 | `bash tests/test_scaffold.sh python` | Single language test | Debugging specific language scaffold |
+| `bash tests/test_scaffold.sh archetypes` | All archetype tests (4 suites) | After archetype changes |
 | `bash tests/test_scaffold.sh keep` | --keep flag test | After changes to cleanup logic |
+| `bash tests/test_scaffold.sh dry-run` | --dry-run flag test | After changes to dry-run logic |
 | `bash tests/test_scaffold.sh permissions` | Permissions test | After changes to permission logic |
 | `make test` | Full suite (all tiers) | Before PR, CI validation |
 | `make test-unit` | Tier 1 — Unit tests | During development, before commit |
@@ -26,7 +28,7 @@
 
 | Module / Component | Unit | Integration | Agent Behavior | Priority Gap |
 |-------------------|------|-------------|----------------|--------------|
-| scaffold (init script) | ❌ 0 | ✅ 347 (7 suites) | ❌ 0 | LOW |
+| scaffold (init script) | ❌ 0 | ✅ 614 (12 suites) | ❌ 0 | LOW |
 | .claude/hooks/protect-main-branch.sh | ❌ 0 | ❌ 0 | ❌ 0 | MEDIUM |
 | .claude/skills/ | ❌ 0 | ❌ 0 | ❌ 0 | LOW |
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,49 +1,47 @@
-# Task Plan — Project Hardening (CI, Safety, DevEx, Docker, Updates, Releases)
+# Task Plan — P1 Features: --dry-run, make setup, Project Archetypes
 
 > Updated: 2026-02-13
-> Branch: `feat/project-hardening`
+> Branch: `feat/p1-features`
 > Status: Complete
+> Issues: #8, #9, #10
 
 ## Objective
 
-Add 9 features that harden scaffolded projects for real-world use: CI workflows, pre-commit hooks, secret scanning, health checks, environment templates, Docker support, an update mechanism, and a release workflow.
+Implement the three P1-high features: `--dry-run` preview mode, `make setup` bootstrap target, and project archetypes (CLI, API, library).
 
 ## Plan
 
-### Phase 1: CI Workflows — items #1, #4
-- [x] 1. Create `.github/workflows/ci.yml` for scaffold repo itself
-- [x] 2. Add CI template generation to scaffold — per-language setup
-- [x] 3. Add test assertions for generated CI workflow
+### Phase 1: `--dry-run` flag (#10)
 
-### Phase 2: Pre-commit + Secret Scanning — items #2, #3
-- [x] 4. Create per-language `.pre-commit-config.yaml` generation
-- [x] 5. Add secret scanning via `detect-secrets` pre-commit hook
-- [x] 6. Add test assertions for pre-commit config
+- [x] 1. Add `DRY_RUN=false` global
+- [x] 2. Add `--dry-run` to `parse_flags()` and `show_help()`
+- [x] 3. Create `dry_run_report()` — prints file tree of what would be created based on choices
+- [x] 4. In `main()`, after all `step_*` prompts but before `apply_templates`: if `DRY_RUN`, call `dry_run_report` and exit
+- [x] 5. Add test: `./scaffold --non-interactive --dry-run` produces no files, exits 0
+- [x] 6. Update header comment with new flag
 
-### Phase 3: /doctor + .env.example — items #5, #7
-- [x] 7. Create `/doctor` skill
-- [x] 8. Add `.env.example` template generation
-- [x] 9. Add test assertions for /doctor skill and .env.example
-- [x] 10. Update slash command count 12 → 13
+### Phase 2: `make setup` target (#9)
 
-### Phase 4: Docker Support — item #8
-- [x] 11. Add Docker step to scaffold (optional)
-- [x] 12. Create per-language Dockerfile templates (multi-stage where applicable)
-- [x] 13. Create `docker-compose.yml` template
-- [x] 14. Add test assertions for Docker files (Docker is optional — no assertions needed for default)
+- [x] 7. Add per-language `SETUP_CMD` variables to Makefile
+- [x] 8. Add `setup` target: run `SETUP_CMD`, `pre-commit install` if config exists
+- [x] 9. Add `setup` to `.PHONY` list and `help` target
+- [x] 10. Update scaffold's `show_summary()` to mention `make setup`
+- [x] 11. Add test: assert Makefile contains `setup` target
+- [x] 12. Update README "Makefile" section
 
-### Phase 5: Update Mechanism — item #6
-- [x] 15. Add `scaffold --update` flag
-- [x] 16. Update `--help` text with new flag
-- [x] 17. Add safety: show diff, require confirmation
+### Phase 3: Project Archetypes (#8)
 
-### Phase 6: CHANGELOG + Release Workflow — item #9
-- [x] 18. Add `CHANGELOG.md` template generation
-- [x] 19. Create `.github/workflows/release.yml` template
-- [x] 20. Add test assertions
+- [x] 13. Add `ARCHETYPE="none"` global
+- [x] 14. Create `step_archetype()` with options: cli, api, library, none
+- [x] 15. Create `apply_archetype()` with 4 languages × 3 archetypes + default
+- [x] 16. Wire `step_archetype()` into `main()` after `step_language()`
+- [x] 17. Add `force_archetype()` helper in tests
+- [x] 18. Add tests: Python×API, TypeScript×CLI, Go×library, Rust×library
+- [x] 19. Update README with archetype section
+- [x] 20. Update show_help to mention archetypes
 
-### Phase 7: Final Polish
-- [x] 21. Update README.md with all new features
-- [x] 22. Update CLAUDE.md skills table
-- [x] 23. Run full test suite — 347/347 passing
-- [x] 24. Commit, push, PR
+### Phase 4: Final Polish
+
+- [x] 21. Run full test suite — 614/614 passing
+- [x] 22. Update README counts and tests.md
+- [x] 23. Commit, push, PR


### PR DESCRIPTION
## Summary
- **`--dry-run`** (#10): Preview what scaffold would create without writing any files
- **`make setup`** (#9): Bootstrap dev environment — install deps + set up pre-commit, per language
- **Project archetypes** (#8): CLI, API, and library starter structures for all 4 languages

## Archetypes

| Archetype | Python | TypeScript | Go | Rust |
|-----------|--------|------------|-----|------|
| CLI | argparse + subcommands | process.argv parser | os.Args switch | std::env match |
| API | http.server + routes | node:http + routes | net/http + internal/routes | TcpListener |
| Library | lib.py with public API | index.ts with exports | root .go with exported funcs | lib.rs with pub fns + tests |

No framework dependencies added — all archetypes use stdlib only.

## Changes
- `scaffold` — added `--dry-run` flag, `step_archetype()`, `apply_archetype()`, `dry_run_report()`
- `Makefile` — added `SETUP_CMD` per language, `setup` target
- `README.md` — archetype section, dry-run mode, make setup in tables, updated counts
- `tests/test_scaffold.sh` — 5 new test suites (dry-run + 4 archetype combos), `force_archetype()` helper
- `tasks/todo.md` — plan with all 23 steps checked off
- `tasks/tests.md` — updated counts (614 assertions, 12 suites)

## Test plan
- [x] Full suite: 614/614 passing (12 suites)
- [x] `--dry-run` creates no files, prints preview
- [x] `make setup` target present in generated Makefile
- [x] Python×API: app.py + routes/health.py generated
- [x] TypeScript×CLI: cli.ts with parseArgs generated
- [x] Go×Library: root .go with exported Hello function
- [x] Rust×Library: lib.rs with pub fn + inline tests

Closes #8, closes #9, closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)