### PR TITLE
feat: P3 features — shell completion, rollback, --add

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,30 @@ Preview what scaffold would create without writing anything:
 ./scaffold --non-interactive --dry-run
 ```
 
+### Shell Completion
+
+Enable tab-completion for scaffold flags:
+
+```bash
+source <(./scaffold --completions)
+
+# Or persist it:
+./scaffold --completions >> ~/.bashrc
+```
+
+### Multi-Language Projects
+
+Layer a second language into an existing scaffolded project:
+
+```bash
+./scaffold --add typescript
+```
+
+This appends TypeScript conventions to `CLAUDE.md`, adds config files (without overwriting existing ones), updates `.gitignore`, adds prefixed Makefile targets (`test-ts`, `lint-ts`, `fmt-ts`, `typecheck-ts`), and updates the CI workflow. Requires templates to be present (use `--keep` on initial run).
+
 ### Keeping Scaffold Artifacts
 
-By default, the `scaffold` script and `templates/` directory are removed after init. To preserve them:
+By default, the `scaffold` script and `templates/` directory are removed after init. To preserve them (required for `--add` and `--update`):
 
 ```bash
 ./scaffold --keep
@@ -364,6 +385,10 @@ When enabled during `./scaffold` init, adds production-ready Docker support:
 - **Dockerfile** — language-specific with multi-stage builds (Go, Rust, TypeScript) or slim images (Python)
 - **docker-compose.yml** — app service with commented-out database example
 
+### Graceful Rollback
+
+If scaffold fails mid-run, it automatically detects files created during the run and offers to clean them up. In non-interactive mode, cleanup happens automatically. Pre-existing files are never deleted.
+
 ### Updating Existing Projects
 
 If scaffold improves after you've already scaffolded a project, you can pull updates:
@@ -420,7 +445,7 @@ Each archetype is language-aware — a Python API uses stdlib `http.server`, a G
 ### Running Tests
 
 ```bash
-# All tests (12 suites, 641 assertions)
+# All tests (15 suites, 667 assertions)
 bash tests/test_scaffold.sh
 
 # Single language
@@ -433,6 +458,10 @@ bash tests/test_scaffold.sh none
 # Feature tests
 bash tests/test_scaffold.sh keep
 bash tests/test_scaffold.sh permissions
+bash tests/test_scaffold.sh dry-run
+bash tests/test_scaffold.sh completions
+bash tests/test_scaffold.sh rollback
+bash tests/test_scaffold.sh add-language
 ```
 
 ### Project Structure for Contributors
@@ -449,7 +478,7 @@ scaffold/
 ├── agents/                     # Agent specifications
 ├── tasks/                      # Plan, lessons, test registry
 ├── tests/
-│   └── test_scaffold.sh        # Behavior tests (641 assertions)
+│   └── test_scaffold.sh        # Behavior tests (667 assertions)
 └── CLAUDE.md                   # Agent constitution (with placeholders)
 ```
 

--- a/scaffold
+++ b/scaffold
@@ -16,8 +16,10 @@
 #   ./scaffold --keep           Don't remove scaffold artifacts after init
 #   ./scaffold --non-interactive Use defaults for all prompts
 #   ./scaffold --dry-run        Preview what would be created
+#   ./scaffold --completions    Output bash completion script
+#   ./scaffold --add <lang>     Layer a second language into existing project
 # =============================================================================
-set -euo pipefail
+set -eEuo pipefail
 
 # ---------------------------------------------------------------------------
 # Globals
@@ -40,6 +42,10 @@ SETUP_KANBAN=false
 ENABLE_DOCKER=false
 ENABLE_VSCODE=false
 ARCHETYPE="none"
+ADD_LANGUAGE=""
+
+# Rollback tracking
+PRE_SNAPSHOT=""
 
 # Colors (disabled if not a terminal)
 if [[ -t 1 ]]; then
@@ -62,6 +68,74 @@ success() { echo -e "${GREEN}✓${RESET} $*"; }
 warn()    { echo -e "${YELLOW}⚠${RESET} $*"; }
 error()   { echo -e "${RED}✗${RESET} $*" >&2; }
 header()  { echo -e "\n${BOLD}═══ $* ═══${RESET}\n"; }
+
+# Snapshot all files that exist before scaffold modifies anything
+snapshot_pre_existing() {
+  PRE_SNAPSHOT="$(mktemp)"
+  find "$SCRIPT_DIR" -not -path "$SCRIPT_DIR/.git/*" -not -name '.git' | sort > "$PRE_SNAPSHOT"
+}
+
+# Rollback handler — called on ERR if trap is set
+rollback_on_failure() {
+  local exit_code=$?
+  echo ""
+  error "Scaffold failed (exit code: $exit_code)"
+  echo ""
+
+  # Find files created since snapshot
+  local post_snapshot
+  post_snapshot="$(mktemp)"
+  find "$SCRIPT_DIR" -not -path "$SCRIPT_DIR/.git/*" -not -name '.git' | sort > "$post_snapshot"
+  local new_files
+  new_files="$(comm -13 "$PRE_SNAPSHOT" "$post_snapshot" || true)"
+  rm -f "$post_snapshot"
+
+  if [[ -z "$new_files" ]]; then
+    warn "No new files were created before the failure."
+    rm -f "$PRE_SNAPSHOT"
+    exit "$exit_code"
+  fi
+
+  warn "The following files were created before the failure:"
+  echo "$new_files" | while IFS= read -r f; do
+    echo "  ${f#"$SCRIPT_DIR"/}"
+  done
+  echo ""
+
+  if [[ "$NON_INTERACTIVE" == true ]]; then
+    warn "Non-interactive mode: cleaning up created files automatically."
+    perform_rollback "$new_files"
+    rm -f "$PRE_SNAPSHOT"
+    exit "$exit_code"
+  fi
+
+  local answer="n"
+  read -rp "Roll back created files? [y/N]: " answer
+  if [[ "${answer,,}" == "y" || "${answer,,}" == "yes" ]]; then
+    perform_rollback "$new_files"
+  else
+    warn "Partial files left in place. Review manually."
+  fi
+  rm -f "$PRE_SNAPSHOT"
+  exit "$exit_code"
+}
+
+# Remove files created during the run, deepest first
+perform_rollback() {
+  local new_files="$1"
+  local removed=0
+  # Sort in reverse so deeper paths are removed first
+  echo "$new_files" | sort -r | while IFS= read -r f; do
+    if [[ -f "$f" ]]; then
+      rm -f "$f"
+      removed=$((removed + 1))
+    elif [[ -d "$f" ]] && [[ -z "$(ls -A "$f" 2>/dev/null)" ]]; then
+      rmdir "$f" 2>/dev/null || true
+      removed=$((removed + 1))
+    fi
+  done
+  success "Rolled back created files."
+}
 
 # Escape string for use as sed replacement (handles /, &, \, newlines)
 sed_escape() {
@@ -235,6 +309,35 @@ run_update() {
   info "Review changes with: git diff"
 }
 
+# ---------------------------------------------------------------------------
+# Shell completions
+# ---------------------------------------------------------------------------
+print_completions() {
+  cat <<'COMP'
+# Bash completion for scaffold
+# Enable: source <(./scaffold --completions)
+# Persist: ./scaffold --completions >> ~/.bashrc
+
+_scaffold_completions() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  # Complete language after --add
+  if [[ "$prev" == "--add" ]]; then
+    COMPREPLY=($(compgen -W "python typescript go rust" -- "$cur"))
+    return
+  fi
+
+  # Complete flags
+  local flags="--help --keep --non-interactive --dry-run --update --completions --add"
+  COMPREPLY=($(compgen -W "$flags" -- "$cur"))
+}
+
+complete -F _scaffold_completions ./scaffold
+complete -F _scaffold_completions scaffold
+COMP
+}
+
 parse_flags() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -258,6 +361,21 @@ parse_flags() {
         run_update
         exit 0
         ;;
+      --completions)
+        print_completions
+        exit 0
+        ;;
+      --add)
+        if [[ -z "${2:-}" ]]; then
+          error "--add requires a language argument (python, typescript, go, rust)"
+          exit 1
+        fi
+        case "$2" in
+          python|typescript|go|rust) ADD_LANGUAGE="$2" ;;
+          *) error "Unsupported language: $2 (choose: python, typescript, go, rust)"; exit 1 ;;
+        esac
+        shift 2
+        ;;
       *)
         error "Unknown flag: $1"
         echo "Run './scaffold --help' for usage."
@@ -280,6 +398,9 @@ Options:
   --non-interactive   Use defaults for all prompts (for CI/automation)
   --dry-run           Preview what would be created without writing anything
   --update            Update skills, agents, and hooks from scaffold repo
+  --completions       Output bash completion script
+  --add <lang>        Layer a second language into an existing project
+                      Supported: python, typescript, go, rust
 
 What it does:
   1. Asks for project name, description, language, and archetype
@@ -2308,10 +2429,247 @@ show_summary() {
 }
 
 # ---------------------------------------------------------------------------
+# Add language mode — layer a second language into existing project
+# ---------------------------------------------------------------------------
+run_add_language() {
+  local lang="$ADD_LANGUAGE"
+
+  header "Adding $lang to existing project"
+
+  # Validate project has been scaffolded already
+  if [[ ! -f "$SCRIPT_DIR/CLAUDE.md" ]]; then
+    error "No CLAUDE.md found. Run ./scaffold first to initialize the project."
+    exit 1
+  fi
+
+  if [[ ! -d "$SCRIPT_DIR/templates/$lang" ]]; then
+    error "Templates for $lang not found. Make sure scaffold templates are present (use --keep on initial run)."
+    exit 1
+  fi
+
+  # --- Append language conventions to CLAUDE.md (skip if already present) ---
+  local convention_header=""
+  case "$lang" in
+    python)     convention_header="Python Conventions" ;;
+    typescript) convention_header="TypeScript Conventions" ;;
+    go)         convention_header="Go Conventions" ;;
+    rust)       convention_header="Rust Conventions" ;;
+  esac
+
+  if grep -q "$convention_header" "$SCRIPT_DIR/CLAUDE.md" 2>/dev/null; then
+    info "$convention_header already in CLAUDE.md — skipping"
+  elif [[ -f "$SCRIPT_DIR/templates/$lang/CONVENTIONS.md" ]]; then
+    info "Appending $lang conventions to CLAUDE.md..."
+    echo "" >> "$SCRIPT_DIR/CLAUDE.md"
+    echo "---" >> "$SCRIPT_DIR/CLAUDE.md"
+    echo "" >> "$SCRIPT_DIR/CLAUDE.md"
+    cat "$SCRIPT_DIR/templates/$lang/CONVENTIONS.md" >> "$SCRIPT_DIR/CLAUDE.md"
+    success "CLAUDE.md updated with $lang conventions"
+  fi
+
+  # --- Install language config files (don't overwrite existing) ---
+  info "Installing $lang config files..."
+  local tmpl_dir="$SCRIPT_DIR/templates/$lang"
+
+  # Detect project name from existing CLAUDE.md or directory name
+  PROJECT_NAME="${PROJECT_NAME:-$(basename "$SCRIPT_DIR")}"
+  PROJECT_DESC="${PROJECT_DESC:-A project built with Claude Code}"
+  local escaped_name escaped_desc
+  escaped_name="$(sed_escape "$PROJECT_NAME")"
+  escaped_desc="$(sed_escape "$PROJECT_DESC")"
+
+  # Process .tmpl files (skip if target exists)
+  for tmpl in "$tmpl_dir"/*.tmpl; do
+    if [[ -f "$tmpl" ]]; then
+      local dest_name
+      dest_name="$(basename "$tmpl" .tmpl)"
+      if [[ -f "$SCRIPT_DIR/$dest_name" ]]; then
+        info "  Skipping $dest_name (already exists)"
+      else
+        sed "s/{{PROJECT_NAME}}/${escaped_name}/g; s/{{PROJECT_DESCRIPTION}}/${escaped_desc}/g" \
+          "$tmpl" > "$SCRIPT_DIR/$dest_name"
+        success "  Created $dest_name"
+      fi
+    fi
+  done
+
+  # Copy non-template config files (skip if target exists)
+  for cfg in "$tmpl_dir"/*; do
+    local basename
+    basename="$(basename "$cfg")"
+    if [[ "$basename" != "CONVENTIONS.md" && \
+          "$basename" != "gitignore.append" && \
+          "$basename" != *.tmpl && \
+          -f "$cfg" ]]; then
+      if [[ -f "$SCRIPT_DIR/$basename" ]]; then
+        info "  Skipping $basename (already exists)"
+      else
+        cp "$cfg" "$SCRIPT_DIR/$basename"
+        success "  Created $basename"
+      fi
+    fi
+  done
+
+  # --- Append to .gitignore (don't duplicate entries) ---
+  if [[ -f "$tmpl_dir/gitignore.append" ]]; then
+    info "Updating .gitignore with $lang entries..."
+    while IFS= read -r line; do
+      if [[ -n "$line" && "$line" != \#* ]]; then
+        if ! grep -qxF "$line" "$SCRIPT_DIR/.gitignore" 2>/dev/null; then
+          echo "$line" >> "$SCRIPT_DIR/.gitignore"
+        fi
+      elif [[ "$line" == \#* ]]; then
+        # Add comment headers if not already present
+        if ! grep -qxF "$line" "$SCRIPT_DIR/.gitignore" 2>/dev/null; then
+          echo "$line" >> "$SCRIPT_DIR/.gitignore"
+        fi
+      fi
+    done < "$tmpl_dir/gitignore.append"
+    success "  .gitignore updated"
+  fi
+
+  # --- Add prefixed Makefile targets ---
+  info "Adding $lang Makefile targets..."
+  local lang_short=""
+  local test_cmd="" lint_cmd="" fmt_cmd="" typecheck_cmd=""
+  case "$lang" in
+    python)
+      lang_short="py"
+      test_cmd="python -m pytest tests/ -v"
+      lint_cmd="ruff check ."
+      fmt_cmd="ruff format ."
+      typecheck_cmd="mypy src/"
+      ;;
+    typescript)
+      lang_short="ts"
+      test_cmd="npx vitest run"
+      lint_cmd="npx eslint src/"
+      fmt_cmd="npx prettier --write src/"
+      typecheck_cmd="npx tsc --noEmit"
+      ;;
+    go)
+      lang_short="go"
+      test_cmd="go test ./..."
+      lint_cmd="golangci-lint run"
+      fmt_cmd="gofmt -w ."
+      typecheck_cmd="go vet ./..."
+      ;;
+    rust)
+      lang_short="rs"
+      test_cmd="cargo test"
+      lint_cmd="cargo clippy -- -D warnings"
+      fmt_cmd="cargo fmt"
+      typecheck_cmd="cargo check"
+      ;;
+  esac
+
+  if grep -q "^test-${lang_short}:" "$SCRIPT_DIR/Makefile" 2>/dev/null; then
+    info "  Makefile targets for $lang already exist — skipping"
+  else
+    cat >> "$SCRIPT_DIR/Makefile" <<MKEOF
+
+# --- ${lang} targets (added via --add) ---
+.PHONY: test-${lang_short} lint-${lang_short} fmt-${lang_short} typecheck-${lang_short}
+
+test-${lang_short}:
+	${test_cmd}
+
+lint-${lang_short}:
+	${lint_cmd}
+
+fmt-${lang_short}:
+	${fmt_cmd}
+
+typecheck-${lang_short}:
+	${typecheck_cmd}
+MKEOF
+    success "  Added test-${lang_short}, lint-${lang_short}, fmt-${lang_short}, typecheck-${lang_short}"
+  fi
+
+  # --- Update CI workflow to include second language ---
+  local ci_file="$SCRIPT_DIR/.github/workflows/ci.yml"
+  if [[ -f "$ci_file" ]]; then
+    if grep -q "$lang" "$ci_file" 2>/dev/null; then
+      info "  CI already references $lang — skipping"
+    else
+      info "Updating CI workflow for $lang..."
+      local ci_step=""
+      case "$lang" in
+        python) ci_step="
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install -e '.[dev]'
+
+      - name: Run Python checks
+        run: make test-py && make lint-py" ;;
+        typescript) ci_step="
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install TypeScript dependencies
+        run: npm ci
+
+      - name: Run TypeScript checks
+        run: make test-ts && make lint-ts" ;;
+        go) ci_step="
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Run Go checks
+        run: make test-go && make lint-go" ;;
+        rust) ci_step="
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Run Rust checks
+        run: make test-rs && make lint-rs" ;;
+      esac
+
+      # Insert new language steps before the final "Run checks" step
+      if [[ -n "$ci_step" ]]; then
+        local ci_tmp
+        ci_tmp="$(mktemp)"
+        awk -v steps="$ci_step" '
+          /- name: Run checks/ { print steps; print ""; }
+          { print }
+        ' "$ci_file" > "$ci_tmp"
+        mv "$ci_tmp" "$ci_file"
+        success "  CI workflow updated with $lang steps"
+      fi
+    fi
+  fi
+
+  echo ""
+  success "Successfully added $lang to your project."
+  info "Review changes with: git diff"
+  info "New Makefile targets: test-${lang_short}, lint-${lang_short}, fmt-${lang_short}, typecheck-${lang_short}"
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 main() {
   parse_flags "$@"
+
+  # --add mode: layer a second language and exit
+  if [[ -n "$ADD_LANGUAGE" ]]; then
+    run_add_language
+    exit 0
+  fi
 
   echo ""
   echo -e "${BOLD}╔═══════════════════════════════════════════════════╗${RESET}"
@@ -2335,10 +2693,19 @@ main() {
     exit 0
   fi
 
+  # Snapshot existing files and enable rollback on failure
+  snapshot_pre_existing
+  trap rollback_on_failure ERR
+
   apply_templates
   cleanup_artifacts
   init_git
   apply_github_pm
+
+  # Disable rollback trap — we succeeded
+  trap - ERR
+  rm -f "$PRE_SNAPSHOT"
+
   show_summary
 }
 

--- a/tasks/tests.md
+++ b/tasks/tests.md
@@ -9,12 +9,15 @@
 
 | Command | Scope | When to Use |
 |---------|-------|-------------|
-| `bash tests/test_scaffold.sh` | All scaffold behavior tests (12 suites, 641 assertions) | Before PR, after scaffold changes |
+| `bash tests/test_scaffold.sh` | All scaffold behavior tests (15 suites, 667 assertions) | Before PR, after scaffold changes |
 | `bash tests/test_scaffold.sh python` | Single language test | Debugging specific language scaffold |
 | `bash tests/test_scaffold.sh archetypes` | All archetype tests (4 suites) | After archetype changes |
 | `bash tests/test_scaffold.sh keep` | --keep flag test | After changes to cleanup logic |
 | `bash tests/test_scaffold.sh dry-run` | --dry-run flag test | After changes to dry-run logic |
 | `bash tests/test_scaffold.sh permissions` | Permissions test | After changes to permission logic |
+| `bash tests/test_scaffold.sh completions` | --completions flag test | After changes to completion script |
+| `bash tests/test_scaffold.sh rollback` | Rollback on failure test | After changes to rollback logic |
+| `bash tests/test_scaffold.sh add-language` | --add flag test | After changes to multi-language logic |
 | `make test` | Full suite (all tiers) | Before PR, CI validation |
 | `make test-unit` | Tier 1 — Unit tests | During development, before commit |
 | `make test-integration` | Tier 2 — Integration tests | Before PR |
@@ -28,7 +31,7 @@
 
 | Module / Component | Unit | Integration | Agent Behavior | Priority Gap |
 |-------------------|------|-------------|----------------|--------------|
-| scaffold (init script) | ❌ 0 | ✅ 641 (12 suites) | ❌ 0 | LOW |
+| scaffold (init script) | ❌ 0 | ✅ 667 (15 suites) | ❌ 0 | LOW |
 | .claude/hooks/protect-main-branch.sh | ❌ 0 | ❌ 0 | ❌ 0 | MEDIUM |
 | .claude/skills/ | ❌ 0 | ❌ 0 | ❌ 0 | LOW |
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,34 +1,38 @@
-# Task Plan — P2 Features: IDE Settings, README Badges, SECURITY.md, /refactor
+# Task Plan — P3 Features: Shell Completion, Graceful Rollback, Multi-Language --add
 
 > Updated: 2026-02-13
-> Branch: `feat/p2-features`
+> Branch: `feat/p3-features`
 > Status: Complete
-> Issues: #11, #12, #13, #14
+> Issues: #15, #16, #17
 
 ## Objective
 
-Implement four P2-medium features: VS Code IDE settings, README badges, SECURITY.md template, and /refactor skill.
+Implement three P3-low features: shell completion for scaffold flags, graceful rollback on failure, and multi-language `--add` flag.
 
 ## Plan
 
-### Phase 1: SECURITY.md (#13) + README Badges (#12)
-- [x] 1. Add SECURITY.md template generation to `apply_templates()`
-- [x] 2. Add badges (CI, license, language) to generated project README
-- [x] 3. Add test assertions for SECURITY.md and badges
+### Phase 1: Shell Completion (#15)
+- [x] 1. Add `--completions` flag to `parse_flags()` that outputs a bash completion script
+- [x] 2. Completion script covers all flags: `--help`, `--keep`, `--non-interactive`, `--dry-run`, `--update`, `--completions`
+- [x] 3. Add test assertions for `--completions` output
+- [x] 4. Document in README how to enable (`source <(./scaffold --completions)`)
 
-### Phase 2: IDE Settings (#11)
-- [x] 4. Add `ENABLE_VSCODE=false` global + `step_vscode()` prompt
-- [x] 5. Generate `.vscode/settings.json` per language (formatter, ruler, tab size)
-- [x] 6. Generate `.vscode/extensions.json` per language (recommended extensions)
-- [x] 7. Wire into `main()`, update dry-run report
-- [x] 8. Add test assertions
+### Phase 2: Graceful Rollback (#16)
+- [x] 5. Track files created during the run (array of paths)
+- [x] 6. Add `trap` handler on ERR that lists partial files and offers rollback
+- [x] 7. Never delete files that existed before scaffold ran (snapshot pre-existing files)
+- [x] 8. Add test assertions for rollback behavior
 
-### Phase 3: /refactor Skill (#14)
-- [x] 9. Create `.claude/skills/refactor/SKILL.md`
-- [x] 10. Update command count 13 → 14 everywhere
-- [x] 11. Add test assertion for refactor skill
+### Phase 3: Multi-Language `--add` (#17)
+- [x] 9. Add `--add <language>` flag to `parse_flags()`
+- [x] 10. In add mode: skip project basics/permissions/git init, only layer language config
+- [x] 11. Append language conventions to CLAUDE.md (without duplicating existing sections)
+- [x] 12. Append to .gitignore (not overwrite)
+- [x] 13. Update Makefile with prefixed targets (e.g., `test-ts`, `lint-ts`)
+- [x] 14. Update CI workflow to include both languages
+- [x] 15. Add test assertions for at least one `--add` scenario
 
 ### Phase 4: Polish
-- [x] 12. Update README (new sections, counts, trees)
-- [x] 13. Run full test suite
-- [x] 14. Commit, push, PR
+- [x] 16. Update README (new flags, counts)
+- [x] 17. Run full test suite
+- [x] 18. Commit, push, PR


### PR DESCRIPTION
## Summary

- **Shell completion** (#15): `--completions` flag outputs a bash completion script with all flags + language options for `--add`
- **Graceful rollback** (#16): `trap ERR` handler with filesystem snapshot — on failure, lists partial files and auto-cleans (non-interactive) or prompts (interactive). Never deletes pre-existing files
- **Multi-language `--add`** (#17): `--add <language>` layers a second language into an existing project — appends conventions to CLAUDE.md, installs config files (no overwrite), appends to .gitignore, adds prefixed Makefile targets (`test-ts`, `lint-ts`, etc.), and updates CI workflow. Idempotent on re-run

## Test plan

- [x] 667/667 assertions pass across 15 test suites
- [x] `--completions` outputs valid bash completion with all flags + language options
- [x] Rollback auto-cleans on failure in non-interactive mode
- [x] Rollback detects injected failure and prints created files
- [x] `--add typescript` on python project creates TS config, preserves Python files
- [x] CLAUDE.md has both language conventions after `--add`
- [x] .gitignore has both language entries after `--add`
- [x] Makefile has prefixed targets after `--add`
- [x] CI workflow includes both language setups after `--add`
- [x] Running `--add` twice is idempotent (no duplicates)
- [x] All existing 12 test suites still pass

Closes #15, closes #16, closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)