### PR TITLE
test: hook tests + bump to v1.0.0

### DIFF
--- a/scaffold
+++ b/scaffold
@@ -60,7 +60,7 @@ ADD_DIR=""
 ADD_MODE=false
 VERIFY_MODE=false
 MIGRATE_MODE=false
-SCAFFOLD_VERSION="0.3.0"
+SCAFFOLD_VERSION="1.0.0"
 
 # Rollback tracking
 PRE_SNAPSHOT=""

--- a/tasks/tests.md
+++ b/tasks/tests.md
@@ -9,7 +9,7 @@
 
 | Command | Scope | When to Use |
 |---------|-------|-------------|
-| `bash tests/test_scaffold.sh` | All scaffold behavior tests (32 suites, 721 assertions) | Before PR, after scaffold changes |
+| `bash tests/test_scaffold.sh` | All scaffold behavior tests (33 suites, 732 assertions) | Before PR, after scaffold changes |
 | `bash tests/test_scaffold.sh python` | Single language test | Debugging specific language scaffold |
 | `bash tests/test_scaffold.sh archetypes` | All archetype tests (4 suites) | After archetype changes |
 | `bash tests/test_scaffold.sh keep` | --keep flag test | After changes to cleanup logic |
@@ -34,6 +34,7 @@
 | `bash tests/test_scaffold.sh verify-fail` | --verify failure detection test | After verify logic changes |
 | `bash tests/test_scaffold.sh install-tpl` | --install-template test | After template registry changes |
 | `bash tests/test_scaffold.sh install-tpl-bad` | Invalid template rejection test | After template registry changes |
+| `bash tests/test_scaffold.sh hook-protect` | protect-main-branch hook test | After hook changes |
 | `make test` | Full suite (all tiers) | Before PR, CI validation |
 | `make test-unit` | Tier 1 — Unit tests | During development, before commit |
 | `make test-integration` | Tier 2 — Integration tests | Before PR |
@@ -48,7 +49,7 @@
 | Module / Component | Unit | Integration | Agent Behavior | Priority Gap |
 |-------------------|------|-------------|----------------|--------------|
 | scaffold (init script) | ❌ 0 | ✅ 721 (32 suites) | ❌ 0 | LOW |
-| .claude/hooks/protect-main-branch.sh | ❌ 0 | ❌ 0 | ❌ 0 | MEDIUM |
+| .claude/hooks/protect-main-branch.sh | ✅ 11 (1 suite) | ❌ 0 | ❌ 0 | LOW |
 | .claude/skills/ | ❌ 0 | ❌ 0 | ❌ 0 | LOW |
 
 > **Legend**: ✅ = covered (count), ❌ = missing (0), 🟡 = partial
@@ -91,7 +92,7 @@
 ## Coverage Gaps & TODO
 
 - [x] Scaffold behavior tests for all 4 languages + none + --keep + permissions
-- [ ] Hook tests (protect-main-branch.sh) — mock git branch, verify JSON output
+- [x] Hook tests (protect-main-branch.sh) — 11 assertions: deny on main/master, allow on feature, valid JSON, helpful message
 - [ ] Makefile target tests — verify each language's targets resolve correctly
 
 ---


### PR DESCRIPTION
## Summary

- Add 11 test assertions for `protect-main-branch.sh` hook — closes the last MEDIUM test coverage gap
- Bump `SCAFFOLD_VERSION` from `0.3.0` to `1.0.0`

## Hook test coverage

| Test | Assertion |
|------|-----------|
| 1 | `git commit` on main → denied |
| 2 | `git push` on main → denied |
| 3 | Deny output contains branch creation suggestion |
| 4 | Deny output is valid JSON |
| 5 | `git commit` on feature branch → allowed |
| 6 | `git push` on feature branch → allowed |
| 7 | `git status` → allowed |
| 8 | `git log` → allowed |
| 9 | `git commit` on master → denied |
| 10 | Malformed input → no crash |
| 11 | Hook always exits 0 |

## Test plan

- [x] `bash tests/test_scaffold.sh hook-protect` — 11/11 pass
- [x] Full suite: **732/732 assertions across 33 suites**

🤖 Generated with [Claude Code](https://claude.com/claude-code)