### PR TITLE
feat: add Claude Code GitHub Action (keyless WIF auth)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,54 @@
+name: Claude Code
+
+# Auto-reviews every PR and responds to @claude mentions in issue/PR comments.
+# Auth: Workload Identity Federation (keyless) — the action swaps GitHub's OIDC
+# token for a short-lived Anthropic token, so there is NO ANTHROPIC_API_KEY to
+# store or rotate. The fdrl_/svac_/org-UUID values below are identifiers, not
+# credentials, so they live in-repo by design.
+#
+# Federation rule fdrl_01QrWEGMrXHmz5FtKb23Ckux is scoped to subject prefix
+# repo:sakebomb/* (claim repository_owner=sakebomb), so every sakebomb repo
+# shares this same workflow + identifiers. Console: Settings → Workload identity.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    # Skip comment events that don't tag @claude so we don't burn runner minutes
+    # on every comment; PR events always run (auto-review).
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read     # lets the github_ci MCP server read CI/check status during reviews
+      id-token: write   # REQUIRED for WIF: lets the action fetch a GitHub OIDC token
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          # --- WIF identifiers (rule scoped to repo:sakebomb/*) --------------
+          # These are identifiers, not credentials — safe to keep in-repo.
+          anthropic_federation_rule_id: fdrl_01QrWEGMrXHmz5FtKb23Ckux
+          anthropic_organization_id: 1d3bf4a1-f7b8-47d9-8cda-850a04b89ee3
+          anthropic_service_account_id: svac_01TfdVVK716pxAGtc8rLezMG
+          anthropic_workspace_id: wrkspc_01SEA76zmcMvsuYcL8cDY3S9
+          # -------------------------------------------------------------------
+
+          # Auto PR review supplies a review prompt; mentions use the comment body.
+          prompt: ${{ github.event_name == 'pull_request' && 'Review this PR for correctness, security, and adherence to the repo conventions in CLAUDE.md. Flag CRITICAL/HIGH issues clearly; keep notes concise.' || '' }}
+          trigger_phrase: "@claude"
+          track_progress: "true"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude.yml` — auto-reviews PRs and answers `@claude` mentions.
- **Keyless auth** via Workload Identity Federation (no `ANTHROPIC_API_KEY` secret). The `fdrl_`/`svac_`/`wrkspc_`/org-UUID inputs are identifiers, not credentials.
- Federation rule is scoped to `repo:sakebomb/*` + `repository_owner=sakebomb`.

## Test plan
- [ ] The introducing PR self-skips (anti-tampering guard) — expected. Real auth runs after merge to the default branch.
- [ ] After merge: confirm an `@claude` comment gets a reply.

> Requires the `fdrl_01QrWEGMrXHmz5FtKb23Ckux` federation rule to be scoped to `repo:sakebomb/*` (one-time console change).